### PR TITLE
chore(deps): bump hono and qs overrides to clear 5 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2310,9 +2310,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3061,9 +3061,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -40,11 +40,12 @@
     "zod": "^4.3.6"
   },
   "overrides": {
-    "hono": "^4.12.18",
+    "hono": "^4.12.21",
     "@hono/node-server": "^1.19.13",
     "postcss": "^8.5.10",
     "ip-address": "^10.1.1",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.2",
+    "qs": "^6.15.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",


### PR DESCRIPTION
Clears all 5 open Dependabot alerts (5 medium) by bumping the transitive-dep override floors and regenerating the lockfile.

## Why not Dependabot's own PRs

hono and qs are transitive deps under `@modelcontextprotocol/sdk`, pinned by the existing `overrides` block in package.json. Dependabot's lockfile-only update runs **failed** because they bump the lockfile without updating the `overrides` entry, leaving the two inconsistent. Bumping the override floor + regenerating the lockfile in one commit is the correct fix. This PR supersedes the `dependabot/npm_and_yarn/hono-4.12.23` and `dependabot/npm_and_yarn/qs-6.15.2` branches.

## Changes

- hono override `^4.12.18 -> ^4.12.21` (resolves to **4.12.23**): clears 4 medium alerts -- Set-Cookie injection via cookie helper, `app.mount()` undecoded-prefix routing, IPv6 deny-rule bypass, JWT middleware accepting any auth scheme.
- add qs override `^6.15.2` (resolves to **6.15.2**): clears 1 medium alert -- `qs.stringify` DoS on null/undefined entries in comma-format arrays.

## Verification

- `npm audit`: **0 vulnerabilities**
- `npm run build` (tsup): success
- `npm test`: 215 passed / 8 skipped / 0 failed

Note: these overrides scope to this repo's own dev/CI dependency tree (what Dependabot scans); published consumers resolve their own tree from the two direct deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)