### PR TITLE
feat: support unix-socket admin, ACME profiles, ECH status, and snapshot persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **String values were sent as raw request bodies on every config write.** A config
+  write's body is a JSON *value*, so a string has to be JSON-encoded; caddy-mcp sent it
+  bare and Caddy answered `500 {"error":"decoding request body: invalid character 'x'
+  looking for beginning of value, at offset 1"}`. This broke `caddy_tls set_email` /
+  `set_acme_ca` / `set_acme_profile`, and `caddy_config_set` / `caddy_config_by_id`
+  whenever the value was a string. `POST /load` and `POST /adapt` still send a raw
+  document (a Caddyfile must not be JSON-encoded), so the raw passthrough is now opt-in
+  per call site instead of applying to every string body.
+- **`caddy_tls`'s clobber-safe fallback used `PUT`, which could never succeed.** Caddy's
+  `PUT` on a non-array key is strictly-create and returns `409 "key already exists: tls"`
+  whenever `apps/tls` is present -- exactly the condition the fallback runs under. It now
+  uses `PATCH`, which requires the key to exist. Together with the encoding bug above,
+  `caddy_tls` write actions only ever succeeded against an instance that had no
+  `apps/tls` block at all.
+
+  Both were invisible to the unit tests, which mock the api module and so never see Caddy
+  reject a verb or a body. The live-Caddy integration suite now pins both, and it runs in
+  `release.sh`.
 - A `CADDY_ADMIN_URL` that plainly means "unix socket" but does not parse as one --
   `unix:/run/caddy.sock` (a single slash) or `unix://relative.sock` -- used to fall
   through to the TCP path and report `Cannot connect to Caddy admin API at null`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `CADDY_ADMIN_URL` that plainly means "unix socket" but does not parse as one --
+  `unix:/run/caddy.sock` (a single slash) or `unix://relative.sock` -- used to fall
+  through to the TCP path and report `Cannot connect to Caddy admin API at null`,
+  naming neither the socket nor the mistake. It now fails immediately with the two
+  accepted spellings, and without burning the retry budget on what is a static
+  configuration error.
 - README reported "230 unit tests; +8 live-Caddy integration tests"; the actual counts
   are 313 and 9.
 - Documented that since Caddy 2.11.1, `SIGUSR1` reloads from the Caddyfile **only** if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Unix socket admin endpoints.** `CADDY_ADMIN_URL` now accepts `unix:///var/run/caddy-admin.sock`
+  (and Caddy's own `unix//var/run/caddy-admin.sock` spelling), routing requests through
+  `node:http` with `socketPath` instead of the global `fetch`, which cannot dial a unix
+  socket at all. Moving the admin API onto a unix socket is Caddy's own hardening
+  recommendation, and those instances were previously unreachable. The unix path sends
+  **no** `Origin` header — the exact opposite of the TCP path: Caddy builds no default
+  origin allowlist for a unix/fd admin listener and only runs its origin check when
+  `Origin` or `Sec-Fetch-Mode` is present, so sending one opts into a check against an
+  empty allowlist and always 403s.
+- **`caddy_tls` action `set_acme_profile`.** Sets the ACME issuer's `profile` field
+  (Caddy 2.10+). Let's Encrypt uses it to issue 6-day short-lived certificates under
+  the `shortlived` profile. Valid names are defined by the CA, so the value passes
+  through unvalidated.
+- **`caddy_tls` action `ech_status`.** Reads the Encrypted ClientHello config at
+  `apps/tls/ech` (Caddy 2.10+). Read-only: enabling ECH needs a DNS provider credential
+  and a publication policy, which belong in a full config applied via `caddy_load`.
+  ECH is rarely enabled, so an absent config reports "not configured" as the answer
+  rather than surfacing Caddy's raw 404 as a read error.
+- **Optional snapshot persistence.** `CADDY_MCP_SNAPSHOT_DIR` writes each `caddy_revert`
+  snapshot to disk and rehydrates the ring on first access, so a rollback target survives
+  a server restart. Unset keeps the previous memory-only behavior. Opt-in because
+  snapshots are full Caddy configs and can carry secrets. Corrupt files are skipped rather
+  than taking out the ring, and any write failure degrades to in-memory.
+
+### Changed
+
+- `release.sh` now runs the 9 live-Caddy integration tests as part of its check step,
+  against a **scratch** Caddy started on its own admin port (the suite's `beforeEach`
+  does `loadConfig({})`, which would wipe the config of whatever is listening on 2019).
+  Those tests are the only thing pinning the Caddy admin-API contracts this server is
+  built on — PUT-at-an-array-index inserts, PATCH replaces an `@id` in place, stale
+  `If-Match` yields 412 — and `npm test` skips every one of them unless
+  `CADDY_MCP_INTEGRATION=1`, so a Caddy release that changed any of them would previously
+  have shipped silently. `SKIP_INTEGRATION=1` bypasses, mirroring `SKIP_LINT`.
+- The three `caddy_tls` set actions share one `setIssuerField` helper instead of three
+  hand-copied PATCH-then-fallback blocks, so the clobber-safety semantics cannot drift
+  between them.
+
+### Fixed
+
+- README reported "230 unit tests; +8 live-Caddy integration tests"; the actual counts
+  are 313 and 9.
+- Documented that since Caddy 2.11.1, `SIGUSR1` reloads from the Caddyfile **only** if
+  the config has never been changed through the admin API — so the first write from
+  caddy-mcp makes `systemctl reload caddy` a silent no-op.
+
 ## [2.1.0] — 2026-08-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ MCP server for managing Caddy web servers via the admin API. 18 tools across con
 - `src/server.ts` — Creates McpServer, registers all tools and resources. Exports `createCaddyServer()` and `startServer()`.
 - `src/api.ts` — Caddy admin API client (fetch wrapper). All tools call through this. Also owns the retry policy (only idempotent method/path pairs retry) and the ETag `If-Match` cache used for optimistic concurrency.
 - `src/format.ts` — Converts API responses to MCP tool result format.
-- `src/snapshots.ts` — In-memory ring of the last 10 config snapshots (module-level, per-process). Backs `caddy_revert`; auto-captured before `caddy_load`.
+- `src/snapshots.ts` — Ring of the last 10 config snapshots (module-level, per-process). Backs `caddy_revert`; auto-captured before `caddy_load`. In-memory by default; `CADDY_MCP_SNAPSHOT_DIR` persists them to disk and rehydrates on first access, so rollback survives a restart.
 - `src/tools/config.ts` — Low-level config CRUD: get, set, delete, load, revert, config_by_id.
 - `src/tools/routes.ts` — Route management: reverse_proxy shortcut, add_route, list_routes, remove_route.
 - `src/tools/adapt.ts` — Config format conversion (Caddyfile → JSON).
@@ -66,11 +66,12 @@ Read by `src/api.ts`. All optional.
 
 | Var | Default | Purpose |
 |---|---|---|
-| `CADDY_ADMIN_URL` | `http://localhost:2019` | Admin API base URL. Trailing slashes stripped. |
+| `CADDY_ADMIN_URL` | `http://localhost:2019` | Admin API base URL. Trailing slashes stripped. A `unix:///path` or `unix//path` value switches the transport from global `fetch` to `node:http` with `socketPath` — `fetch` cannot dial a unix socket. The unix path deliberately sends **no** `Origin` header: Caddy builds no default origin allowlist for a unix/fd admin listener and only runs its origin check when `Origin` or `Sec-Fetch-Mode` is present, so sending one opts into a check against an empty list and always 403s. |
 | `CADDY_API_TOKEN` | (unset) | Sent as `Authorization: Bearer <token>` when present. |
 | `CADDY_TIMEOUT` | `10000` | Per-request timeout in ms. Values that floor below 1 fall back to the default. |
 | `CADDY_LOAD_TIMEOUT` | `60000` | Timeout for `POST /load` only — larger to allow for TLS provisioning. |
 | `CADDY_MAX_RETRIES` | `2` | Retries on transient failures (network error or 5xx). Hard-capped at 5; exceeding the cap warns once on stderr. Never retries 4xx, including 412. |
+| `CADDY_MCP_SNAPSHOT_DIR` | (unset) | Persist `caddy_revert` snapshots here instead of memory-only. Opt-in because snapshots are full configs and can carry secrets. Write failures degrade to in-memory rather than failing the tool call. |
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ npm install
 npm run lint       # Biome check
 npm run lint:fix   # Auto-fix
 npm run build      # tsup bundle
-npm test           # Vitest (333 unit tests, +2 POSIX-only unix-socket tests; +9 live-Caddy integration tests gated by CADDY_MCP_INTEGRATION=1)
+npm test           # Vitest (348 unit tests, +9 POSIX-only unix-socket tests; +9 live-Caddy integration tests gated by CADDY_MCP_INTEGRATION=1)
 npm run typecheck  # tsc --noEmit
 ```
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ npm install
 npm run lint       # Biome check
 npm run lint:fix   # Auto-fix
 npm run build      # tsup bundle
-npm test           # Vitest (348 unit tests, +9 POSIX-only unix-socket tests; +9 live-Caddy integration tests gated by CADDY_MCP_INTEGRATION=1)
+npm test           # Vitest (357 unit tests, +9 POSIX-only unix-socket tests; +13 live-Caddy integration tests gated by CADDY_MCP_INTEGRATION=1)
 npm run typecheck  # tsc --noEmit
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,28 @@ That's it. Now ask your AI assistant:
 
 | Environment variable | Default | Description |
 |---|---|---|
-| `CADDY_ADMIN_URL` | `http://localhost:2019` | Caddy admin API URL. Set to `http://caddy:2019` inside Docker, or an https URL for remote admin. |
+| `CADDY_ADMIN_URL` | `http://localhost:2019` | Caddy admin API URL. Set to `http://caddy:2019` inside Docker, or an https URL for remote admin. Also accepts a unix socket, in either `unix:///var/run/caddy-admin.sock` or Caddy's own `unix//var/run/caddy-admin.sock` spelling — see below. |
 | `CADDY_API_TOKEN` | (none) | Optional Bearer token for authenticated admin endpoints. Only needed if you've configured Caddy with auth. |
+| `CADDY_MCP_SNAPSHOT_DIR` | (none) | Directory for persisting `caddy_revert` snapshots. Unset, snapshots live in memory only and are lost when this server restarts. Snapshots are full Caddy configs and can contain secrets, so the location is opt-in rather than defaulted. |
 | `CADDY_MAX_RETRIES` | `2` | Number of retries on transient failures (5xx, network errors). 4xx and 412 never retry. POSTs to `/config/*` and `/id/*` also skip retry (non-idempotent appends/creates -- retrying could duplicate routes or 409 a half-applied create). POSTs to `/load`, `/adapt`, `/stop` still retry. Hard-capped at 5; values above the cap log a one-time stderr notice so the clamp is visible. Set to `0` to disable. |
 | `CADDY_TIMEOUT` | `10000` | Timeout in ms for all admin API requests except `/load` (which uses `CADDY_LOAD_TIMEOUT`). Non-numeric, `<= 0`, or fractional values below 1ms fall back to the default. |
 | `CADDY_LOAD_TIMEOUT` | `60000` | Timeout in ms for the `/load` endpoint; raise for ACME-heavy bring-ups where provisioning many certificates can exceed the default. Non-numeric, `<= 0`, or fractional values below 1ms fall back to the default. |
+
+**Unix socket admin endpoints:**
+
+Caddy's recommended hardening is to move the admin API off a loopback port and
+onto a unix socket, where access is governed by filesystem permissions:
+
+```
+{
+  admin unix//var/run/caddy-admin.sock
+}
+```
+
+Point `CADDY_ADMIN_URL` at the same path (`unix:///var/run/caddy-admin.sock`)
+and requests are sent over the socket instead of TCP. The process running
+caddy-mcp needs read/write permission on the socket file. `CADDY_API_TOKEN`
+still applies if you have auth in front of the endpoint.
 
 **Alternate MCP clients:**
 
@@ -217,6 +234,17 @@ Browsable read-only data — MCP clients can fetch these directly without a tool
 - You have `admin.listen` or `admin.origins` restrictions set in your Caddy config, or you're missing an `Authorization` header.
 - Set `CADDY_API_TOKEN` in your MCP config env if Caddy expects a Bearer token.
 
+**`SIGUSR1` / `systemctl reload caddy` stops reloading the Caddyfile**
+
+- Expected, and not caused by a bug here. Since Caddy 2.11.1, `SIGUSR1` reloads
+  from the file on disk **only if the config has never been changed through the
+  admin API**. The first write from caddy-mcp (or any other API client) makes
+  Caddy consider the running config API-owned, and `SIGUSR1` becomes a no-op.
+- Pick one owner per instance. If the Caddyfile is the source of truth, use
+  caddy-mcp read-only tools (`caddy_status`, `caddy_list_routes`, `caddy_adapt`)
+  and reload from the file. If caddy-mcp owns the config, apply changes with
+  `caddy_load` instead of `SIGUSR1`.
+
 **Windows: MCP server doesn't start**
 
 - Use the `cmd /c npx ...` pattern from the Quick start section. Node 20+ can't spawn `.cmd` files directly.
@@ -224,7 +252,9 @@ Browsable read-only data — MCP clients can fetch these directly without a tool
 ## Requirements
 
 - Node.js 20+
-- Caddy 2.x with admin API enabled (default: `localhost:2019`)
+- Caddy 2.x with admin API enabled (default: `localhost:2019`). Verified against
+  Caddy 2.11.4; the `@id` write path relies on `PATCH` semantics that the live
+  integration suite pins per release.
 
 ## Contributing
 
@@ -235,7 +265,7 @@ npm install
 npm run lint       # Biome check
 npm run lint:fix   # Auto-fix
 npm run build      # tsup bundle
-npm test           # Vitest (230 unit tests; +8 live-Caddy integration tests gated by CADDY_MCP_INTEGRATION=1)
+npm test           # Vitest (333 unit tests, +2 POSIX-only unix-socket tests; +9 live-Caddy integration tests gated by CADDY_MCP_INTEGRATION=1)
 npm run typecheck  # tsc --noEmit
 ```
 

--- a/release.sh
+++ b/release.sh
@@ -120,6 +120,64 @@ npm run build || fail "Build failed"
 npm run lint || fail "Lint failed"
 npm run typecheck || fail "Type check failed"
 npm test || fail "Tests failed"
+
+# --- Live-Caddy admin-API semantics gate -------------------------------------
+# The 9 tests in src/tests/integration.test.ts are the ONLY thing pinning the
+# Caddy contracts this server is built on: PUT at an array index INSERTS (it
+# never replaces), PATCH is the verb that replaces an @id in place, a stale
+# If-Match yields 412, and Node's fetch needs a matching Origin to clear Caddy's
+# admin allowlist. `npm test` skips every one of them unless
+# CADDY_MCP_INTEGRATION=1 -- so without this gate, a Caddy release that changed
+# any of those contracts ships silently and breaks only for users.
+#
+# It runs against a SCRATCH Caddy on its own admin port, never whatever the
+# developer has running: the suite's beforeEach does `loadConfig({})`, which
+# would wipe the config of any Caddy listening on 2019.
+#
+# SKIP_INTEGRATION=1 bypasses it (mirrors SKIP_LINT above).
+if [ "${SKIP_INTEGRATION:-}" = "1" ]; then
+  warn "SKIP_INTEGRATION=1 -- live-Caddy admin-API semantics NOT verified for this release"
+elif ! command -v caddy >/dev/null 2>&1; then
+  fail "caddy is not on PATH -- needed to verify admin-API semantics against a scratch instance. Install Caddy, or re-run with SKIP_INTEGRATION=1 to release without that verification."
+else
+  INTEGRATION_ADMIN_PORT="${INTEGRATION_ADMIN_PORT:-2999}"
+  INTEGRATION_ADMIN_URL="http://localhost:${INTEGRATION_ADMIN_PORT}"
+  CADDY_SCRATCH_LOG="$(mktemp -t caddy-release-XXXXXX.log)"
+  CADDY_ADMIN="localhost:${INTEGRATION_ADMIN_PORT}" caddy run >"$CADDY_SCRATCH_LOG" 2>&1 &
+  CADDY_SCRATCH_PID=$!
+  # Reap the scratch instance on EVERY exit path, including `fail`'s exit 1.
+  trap 'kill "$CADDY_SCRATCH_PID" 2>/dev/null || true' EXIT
+
+  for _ in $(seq 1 40); do
+    curl -fsS -m 2 -o /dev/null "${INTEGRATION_ADMIN_URL}/config/" 2>/dev/null && break
+    sleep 0.25
+  done
+  # A successful curl only proves SOMETHING is listening on that port. If our
+  # caddy failed to bind -- most likely the port is already taken by an orphaned
+  # scratch instance from an aborted release -- it has since exited, and the
+  # tests would run against a foreign Caddy whose config the suite's
+  # `loadConfig({})` then wipes. That is exactly what the scratch instance
+  # exists to prevent, so confirm the process WE started is the live one.
+  if ! kill -0 "$CADDY_SCRATCH_PID" 2>/dev/null; then
+    warn "scratch Caddy log: $CADDY_SCRATCH_LOG"
+    fail "scratch Caddy exited -- port ${INTEGRATION_ADMIN_PORT} may already be in use. Refusing to run the integration suite against a Caddy this script did not start (it would wipe that instance's config). Free the port, or set INTEGRATION_ADMIN_PORT to another one."
+  fi
+  if ! curl -fsS -m 2 -o /dev/null "${INTEGRATION_ADMIN_URL}/config/" 2>/dev/null; then
+    warn "scratch Caddy log: $CADDY_SCRATCH_LOG"
+    fail "scratch Caddy never came up on ${INTEGRATION_ADMIN_URL}"
+  fi
+  info "scratch Caddy up on ${INTEGRATION_ADMIN_URL} (pid $CADDY_SCRATCH_PID)"
+
+  CADDY_MCP_INTEGRATION=1 CADDY_ADMIN_URL="$INTEGRATION_ADMIN_URL" \
+    npx vitest run src/tests/integration.test.ts \
+    || fail "Live-Caddy integration tests failed -- Caddy admin-API semantics have changed"
+
+  kill "$CADDY_SCRATCH_PID" 2>/dev/null || true
+  trap - EXIT
+  rm -f "$CADDY_SCRATCH_LOG"
+  info "admin-API semantics verified against $(caddy version 2>/dev/null | head -1)"
+fi
+
 info "All checks passed"
 
 step 2 "Bump version to $VERSION"

--- a/src/api.ts
+++ b/src/api.ts
@@ -224,6 +224,22 @@ function isRetryableMethod(method: string, path: string): boolean {
   return !path.startsWith("/config/") && !path.startsWith("/id/");
 }
 
+/**
+ * A CADDY_ADMIN_URL that plainly means "unix socket" but does not parse as one.
+ *
+ * `unix:/run/caddy.sock` (one slash) and `unix://relative.sock` both fail both
+ * patterns above and would otherwise fall through to the TCP path, where fetch
+ * reports `Cannot connect to Caddy admin API at null` -- an error naming
+ * neither the socket nor the actual mistake. Matching on `unix:` / `unix/`
+ * rather than a bare `unix` prefix so a real host like `unix.example.com:2019`
+ * is not swept up.
+ */
+function getMalformedUnixUrl(): string | undefined {
+  const raw = (process.env.CADDY_ADMIN_URL || "").trim();
+  if (!raw || !/^unix[:/]/i.test(raw)) return undefined;
+  return getUnixSocketPath() === undefined ? raw : undefined;
+}
+
 async function caddyRequest<T = any>(
   method: string,
   path: string,
@@ -231,6 +247,20 @@ async function caddyRequest<T = any>(
   contentType?: string,
   timeout?: number,
 ): Promise<ApiResponse<T>> {
+  // Checked here rather than in attemptRequest so it bypasses the retry loop:
+  // this is a static configuration mistake, and status 0 would otherwise be
+  // treated as a transient failure and replayed.
+  const malformed = getMalformedUnixUrl();
+  if (malformed) {
+    return {
+      ok: false,
+      status: 0,
+      error:
+        `CADDY_ADMIN_URL="${malformed}" looks like a unix socket address but is not a recognized form. ` +
+        `Use "unix:///absolute/path.sock" (URL form) or "unix//absolute/path.sock" (Caddy's own spelling). ` +
+        `A single slash after "unix:", or a relative path, will not parse.`,
+    };
+  }
   const maxRetries = getMaxRetries();
   let attempt = 0;
   let res: ApiResponse<T> = await attemptRequest<T>(method, path, body, contentType, timeout);

--- a/src/api.ts
+++ b/src/api.ts
@@ -246,6 +246,7 @@ async function caddyRequest<T = any>(
   body?: unknown,
   contentType?: string,
   timeout?: number,
+  rawStringBody = false,
 ): Promise<ApiResponse<T>> {
   // Checked here rather than in attemptRequest so it bypasses the retry loop:
   // this is a static configuration mistake, and status 0 would otherwise be
@@ -263,13 +264,13 @@ async function caddyRequest<T = any>(
   }
   const maxRetries = getMaxRetries();
   let attempt = 0;
-  let res: ApiResponse<T> = await attemptRequest<T>(method, path, body, contentType, timeout);
+  let res: ApiResponse<T> = await attemptRequest<T>(method, path, body, contentType, timeout, rawStringBody);
   while (isRetryableMethod(method, path) && isTransientFailure(res) && attempt < maxRetries) {
     attempt++;
     const backoff = Math.min(RETRY_BASE_MS * 2 ** (attempt - 1), RETRY_MAX_DELAY_MS);
     const delay = backoff + Math.random() * RETRY_MAX_JITTER_MS;
     await sleep(delay);
-    res = await attemptRequest<T>(method, path, body, contentType, timeout);
+    res = await attemptRequest<T>(method, path, body, contentType, timeout, rawStringBody);
   }
   return res;
 }
@@ -353,6 +354,7 @@ async function attemptRequest<T = any>(
   body?: unknown,
   contentType?: string,
   timeout?: number,
+  rawStringBody = false,
 ): Promise<ApiResponse<T>> {
   const socketPath = getUnixSocketPath();
   const url = `${getBaseUrl()}${path}`;
@@ -369,7 +371,19 @@ async function attemptRequest<T = any>(
       if (cachedEtag) headers["If-Match"] = cachedEtag;
     }
 
-    const serializedBody = hasBody ? (typeof body === "string" ? body : JSON.stringify(body)) : undefined;
+    // Only /load and /adapt take a raw document as the body (a Caddyfile, an
+    // nginx.conf). Everywhere else the body is a JSON *value*, so a string must
+    // be JSON-encoded -- sending it bare makes Caddy reject the request with
+    //   500 {"error":"decoding request body: invalid character 'x' ..."}
+    // which is what every string-valued config write used to do: caddy_tls's
+    // set_email / set_acme_ca / set_acme_profile, and caddy_config_set or
+    // caddy_config_by_id with a string value. Verified against Caddy 2.11.4:
+    // bare -> 500, JSON-encoded -> 200.
+    const serializedBody = hasBody
+      ? rawStringBody && typeof body === "string"
+        ? body
+        : JSON.stringify(body)
+      : undefined;
     const res = socketPath
       ? await sendViaUnixSocket(socketPath, path, method, headers, serializedBody, effectiveTimeout)
       : await sendViaFetch(url, method, headers, serializedBody, effectiveTimeout);
@@ -537,13 +551,13 @@ function getLoadTimeout(): number {
 }
 
 export async function loadConfig(config: unknown, contentType?: string): Promise<ApiResponse> {
-  const res = await caddyRequest("POST", "/load", config, contentType, getLoadTimeout());
+  const res = await caddyRequest("POST", "/load", config, contentType, getLoadTimeout(), true);
   if (res.ok) etagCache.clear();
   return res;
 }
 
 export function adapt<T = any>(config: string, adapter = "caddyfile"): Promise<ApiResponse<T>> {
-  return caddyRequest<T>("POST", "/adapt", config, `text/${adapter}`);
+  return caddyRequest<T>("POST", "/adapt", config, `text/${adapter}`, undefined, true);
 }
 
 export function stop(): Promise<ApiResponse> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,5 @@
+import { request as httpRequest } from "node:http";
+
 const DEFAULT_URL = "http://localhost:2019";
 const TIMEOUT = 10000;
 const RETRY_BASE_MS = 100;
@@ -75,6 +77,30 @@ function getBaseUrl(): string {
   return (process.env.CADDY_ADMIN_URL || DEFAULT_URL).replace(/\/+$/, "");
 }
 
+/**
+ * The unix socket path when CADDY_ADMIN_URL points at one, else undefined.
+ *
+ * Caddy's own hardening guidance is to move the admin endpoint onto a unix
+ * socket (`admin { listen unix//var/run/caddy-admin.sock }`), where access is
+ * governed by filesystem permissions instead of a loopback port. Node's global
+ * `fetch` cannot dial a unix socket at all, so those instances are unreachable
+ * without a separate transport -- see sendViaUnixSocket.
+ *
+ * Two spellings are accepted, because operators copy from both places:
+ *   - URL form:   unix:///var/run/caddy-admin.sock
+ *   - Caddy form: unix//var/run/caddy-admin.sock  (its network-address syntax,
+ *                 `<network>/<address>`, as written in the admin config)
+ */
+function getUnixSocketPath(): string | undefined {
+  const raw = (process.env.CADDY_ADMIN_URL || "").trim();
+  if (!raw) return undefined;
+  const urlForm = /^unix:\/\/(\/.*)$/.exec(raw);
+  if (urlForm) return urlForm[1];
+  const caddyForm = /^unix\/(\/.*)$/.exec(raw);
+  if (caddyForm) return caddyForm[1];
+  return undefined;
+}
+
 let warnedRetryClamp = false;
 function getMaxRetries(): number {
   const raw = process.env.CADDY_MAX_RETRIES;
@@ -101,11 +127,19 @@ function getAdminOrigin(): string | undefined {
   }
 }
 
-function getHeaders(contentType?: string): Record<string, string> {
+function getHeaders(contentType?: string, overUnixSocket = false): Record<string, string> {
   const headers: Record<string, string> = {};
   if (contentType) headers["Content-Type"] = contentType;
   const token = process.env.CADDY_API_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
+  // Over a unix socket, send NO Origin -- the opposite of the TCP case below.
+  // Caddy builds no default origin allowlist for a unix/fd admin listener (it
+  // reasons that browsers can't reach a unix socket, so DNS rebinding and
+  // cross-site requests don't apply), and it skips the Origin check entirely
+  // unless the request carries an Origin or Sec-Fetch-Mode header. Sending one
+  // opts us INTO a check against an empty allowlist, which always fails. The
+  // node:http transport lets us omit both headers, so we do.
+  if (overUnixSocket) return headers;
   // Node's global fetch ALWAYS sends `Sec-Fetch-Mode: cors`. Caddy's admin API
   // reads that as a browser-initiated cross-origin request and enforces its
   // Origin allowlist; with no Origin header the computed origin is "", which is
@@ -210,6 +244,79 @@ async function caddyRequest<T = any>(
   return res;
 }
 
+/** The transport-agnostic shape both send paths reduce to. */
+interface RawResponse {
+  ok: boolean;
+  status: number;
+  text: string;
+  etag?: string;
+}
+
+/**
+ * Send one request over a unix socket via node:http.
+ *
+ * Errors reject rather than resolve, so attemptRequest's existing catch block
+ * does the classification for both transports. The timeout rejection carries
+ * the literal word "timeout" because that catch matches on it.
+ */
+function sendViaUnixSocket(
+  socketPath: string,
+  path: string,
+  method: string,
+  headers: Record<string, string>,
+  body: string | undefined,
+  timeoutMs: number,
+): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    // AbortSignal.timeout, not req.setTimeout: setTimeout is an INACTIVITY
+    // timer, so a response that trickles bytes steadily would never fire it,
+    // while the fetch path below aborts on an absolute deadline. Using the same
+    // signal here keeps CADDY_TIMEOUT / CADDY_LOAD_TIMEOUT meaning one thing on
+    // both transports. The resulting AbortError message contains "aborted",
+    // which attemptRequest's catch already classifies as a timeout.
+    const req = httpRequest({ socketPath, path, method, headers, signal: AbortSignal.timeout(timeoutMs) }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.on("error", reject);
+      res.on("end", () => {
+        const status = res.statusCode ?? 0;
+        const etag = res.headers.etag;
+        resolve({
+          ok: status >= 200 && status < 300,
+          status,
+          text: Buffer.concat(chunks).toString("utf8"),
+          etag: typeof etag === "string" ? etag : undefined,
+        });
+      });
+    });
+    req.on("error", reject);
+    if (body !== undefined) req.write(body);
+    req.end();
+  });
+}
+
+/** Send one request over TCP via the global fetch. */
+async function sendViaFetch(
+  url: string,
+  method: string,
+  headers: Record<string, string>,
+  body: string | undefined,
+  timeoutMs: number,
+): Promise<RawResponse> {
+  const res = await fetch(url, {
+    method,
+    headers,
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  return {
+    ok: res.ok,
+    status: res.status,
+    text: await res.text(),
+    etag: res.headers.get("ETag") || undefined,
+  };
+}
+
 async function attemptRequest<T = any>(
   method: string,
   path: string,
@@ -217,11 +324,12 @@ async function attemptRequest<T = any>(
   contentType?: string,
   timeout?: number,
 ): Promise<ApiResponse<T>> {
+  const socketPath = getUnixSocketPath();
   const url = `${getBaseUrl()}${path}`;
   const effectiveTimeout = timeout ?? getRequestTimeout();
   try {
     const hasBody = body !== undefined;
-    const headers = getHeaders(hasBody ? contentType || "application/json" : undefined);
+    const headers = getHeaders(hasBody ? contentType || "application/json" : undefined, socketPath !== undefined);
 
     // Send If-Match on config writes when we have a cached ETag for this path
     const isConfigPath = path.startsWith("/config/") || path.startsWith("/id/");
@@ -231,16 +339,14 @@ async function attemptRequest<T = any>(
       if (cachedEtag) headers["If-Match"] = cachedEtag;
     }
 
-    const res = await fetch(url, {
-      method,
-      headers,
-      body: hasBody ? (typeof body === "string" ? body : JSON.stringify(body)) : undefined,
-      signal: AbortSignal.timeout(effectiveTimeout),
-    });
-    const text = await res.text();
+    const serializedBody = hasBody ? (typeof body === "string" ? body : JSON.stringify(body)) : undefined;
+    const res = socketPath
+      ? await sendViaUnixSocket(socketPath, path, method, headers, serializedBody, effectiveTimeout)
+      : await sendViaFetch(url, method, headers, serializedBody, effectiveTimeout);
+    const text = res.text;
 
     // Capture ETag from config GET responses
-    const etag = res.headers.get("ETag") || undefined;
+    const etag = res.etag;
     if (method === "GET" && etag && isConfigPath) {
       setEtag(path, etag);
     }
@@ -284,13 +390,19 @@ async function attemptRequest<T = any>(
       // from the origin Caddy accepts -- say so instead of leaving the caller
       // with a bare "not allowed to access from origin ''".
       if (res.status === 403 && /origin/i.test(text)) {
+        // The remedy differs by transport, and the TCP advice is actively wrong
+        // over a socket -- it would tell the operator to abandon the socket.
+        const hint = socketPath
+          ? `Over a unix socket caddy-mcp deliberately sends no Origin header, because Caddy builds no ` +
+            `default origin allowlist for a unix listener (sending one would fail against an empty list). ` +
+            `Reaching here means admin.enforce_origin is enabled -- disable it, or move the admin endpoint ` +
+            `to a TCP address.`
+          : `Set CADDY_ADMIN_URL to the exact origin Caddy allows (default http://localhost:2019), ` +
+            `or add this origin to the admin.origins list in Caddy's config.`;
         return {
           ok: false,
           status: 403,
-          error:
-            `${text.trim()} -- Caddy's admin API rejected this client's Origin. ` +
-            `Set CADDY_ADMIN_URL to the exact origin Caddy allows (default http://localhost:2019), ` +
-            `or add this origin to the admin.origins list in Caddy's config.`,
+          error: `${text.trim()} -- Caddy's admin API rejected this client's Origin. ${hint}`,
         };
       }
       return { ok: false, status: res.status, error: text };
@@ -303,18 +415,29 @@ async function attemptRequest<T = any>(
     }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
+    // ENOENT is the unix-socket-specific shape: the socket file itself is not
+    // there. Distinguish it from ECONNREFUSED (file present, nothing accepting)
+    // because the fixes differ -- wrong path vs. Caddy not running.
+    if (socketPath && msg.includes("ENOENT")) {
+      return {
+        ok: false,
+        status: 0,
+        error: `No socket at ${socketPath} — check the path in CADDY_ADMIN_URL and that Caddy's admin endpoint is configured to listen on it.`,
+      };
+    }
     if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed")) {
-      const baseUrl = getBaseUrl();
-      let origin = baseUrl;
-      try {
-        origin = new URL(baseUrl).origin;
-      } catch {
-        // fall through — show raw value if unparseable
+      let target = socketPath ?? getBaseUrl();
+      if (!socketPath) {
+        try {
+          target = new URL(target).origin;
+        } catch {
+          // fall through — show raw value if unparseable
+        }
       }
       return {
         ok: false,
         status: 0,
-        error: `Cannot connect to Caddy admin API at ${origin} — is Caddy running?`,
+        error: `Cannot connect to Caddy admin API at ${target} — is Caddy running?`,
       };
     }
     if (msg.includes("abort") || msg.includes("timeout")) {

--- a/src/snapshots.ts
+++ b/src/snapshots.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
 export interface Snapshot {
   config: unknown;
   timestamp: number;
@@ -7,21 +10,144 @@ export interface Snapshot {
 const MAX_SNAPSHOTS = 10;
 const store: Snapshot[] = [];
 
-export function saveSnapshot(config: unknown, trigger: string): void {
-  store.unshift({ config, timestamp: Date.now(), trigger });
-  if (store.length > MAX_SNAPSHOTS) {
-    store.length = MAX_SNAPSHOTS;
+/**
+ * A snapshot must be re-applyable via /load, which requires a JSON object root.
+ * Strings, arrays, null, and primitives are not valid Caddy configs -- refuse to
+ * capture them so a later `caddy_revert apply` can't replay garbage.
+ *
+ * Exported because both entry points into the ring have to agree: the in-memory
+ * save path in tools/config.ts, and the rehydration path below. A file on disk
+ * that merely parses as JSON is not automatically a config.
+ */
+export function isSnapshotableConfig(data: unknown): data is Record<string, unknown> {
+  return data !== null && typeof data === "object" && !Array.isArray(data);
+}
+
+/** Matches the filenames persist() writes: snapshot-<epoch-ms>-<trigger>.json */
+const SNAPSHOT_FILE_RE = /^snapshot-(\d+)-([\w-]+)\.json$/;
+
+/**
+ * Optional on-disk backing for the snapshot ring.
+ *
+ * Default (env unset) is the original behavior: an in-memory ring, per-process,
+ * lost on restart. That is fine for a single interactive session but makes
+ * `caddy_revert` read as more durable than it is -- the rollback target for a
+ * bad `caddy_load` disappears if the MCP server is restarted in between.
+ *
+ * Setting CADDY_MCP_SNAPSHOT_DIR persists each snapshot as its own JSON file
+ * and rehydrates the ring on first access, so rollback survives a restart.
+ * Opt-in rather than default because it writes whole Caddy configs to disk,
+ * and those can carry secrets (ACME EAB keys, upstream credentials) that the
+ * operator should choose to place deliberately.
+ */
+function snapshotDir(): string | undefined {
+  const dir = process.env.CADDY_MCP_SNAPSHOT_DIR?.trim();
+  return dir ? dir : undefined;
+}
+
+let hydrated = false;
+
+/** Read persisted snapshots into the ring once per process, newest first. */
+function hydrate(): void {
+  if (hydrated) return;
+  hydrated = true;
+  const dir = snapshotDir();
+  if (!dir || !existsSync(dir)) return;
+  try {
+    // Sort by NAME and take the newest MAX_SNAPSHOTS before reading anything:
+    // the timestamp is already in the filename, so reading every file only to
+    // discard all but ten would be blocking I/O proportional to whatever the
+    // directory happens to hold. Timestamps are fixed-width epoch millis, so a
+    // lexicographic sort matches a numeric one.
+    const names = readdirSync(dir)
+      .filter((n) => SNAPSHOT_FILE_RE.test(n))
+      .sort()
+      .reverse()
+      .slice(0, MAX_SNAPSHOTS);
+    const loaded: Snapshot[] = [];
+    for (const name of names) {
+      const m = SNAPSHOT_FILE_RE.exec(name);
+      if (!m) continue;
+      try {
+        const config = JSON.parse(readFileSync(join(dir, name), "utf-8")) as unknown;
+        // Same invariant the in-memory save path enforces. Without it, a
+        // hand-edited or truncated-but-still-valid file ("str", [1,2], null)
+        // would enter the ring and get POSTed to /load by `caddy_revert apply`.
+        if (!isSnapshotableConfig(config)) continue;
+        loaded.push({ config, timestamp: Number(m[1]), trigger: m[2] });
+      } catch {
+        // A corrupt or half-written snapshot must not take out the whole ring;
+        // skip it and keep the ones that parse.
+      }
+    }
+    loaded.sort((a, b) => b.timestamp - a.timestamp);
+    store.push(...loaded);
+  } catch {
+    // An unreadable directory degrades to in-memory rather than failing the
+    // tool call -- persistence is a convenience, not a correctness requirement.
   }
 }
 
+/** Mirror the in-memory ring to disk, pruning files beyond MAX_SNAPSHOTS. */
+function persist(snap: Snapshot): void {
+  const dir = snapshotDir();
+  if (!dir) return;
+  try {
+    mkdirSync(dir, { recursive: true });
+    // The trigger is embedded in the filename, so keep it filename-safe. It is
+    // always one of our own literals today ("caddy_load", "manual",
+    // "caddy_revert"); the sanitize keeps that true if a caller passes another.
+    const safeTrigger = snap.trigger.replace(/[^\w-]/g, "_");
+    writeFileSync(
+      join(dir, `snapshot-${snap.timestamp}-${safeTrigger}.json`),
+      JSON.stringify(snap.config, null, 2),
+      "utf-8",
+    );
+    const files = readdirSync(dir)
+      .filter((n) => SNAPSHOT_FILE_RE.test(n))
+      .sort()
+      .reverse();
+    for (const stale of files.slice(MAX_SNAPSHOTS)) {
+      rmSync(join(dir, stale), { force: true });
+    }
+  } catch {
+    // Disk full, read-only mount, bad path -- the in-memory ring already holds
+    // the snapshot, so the revert path still works for this process.
+  }
+}
+
+export function saveSnapshot(config: unknown, trigger: string): void {
+  hydrate();
+  // Two snapshots inside the same millisecond would collide on the filename and
+  // silently overwrite. Nudge forward so each keeps its own file and the ring's
+  // ordering stays strict.
+  let timestamp = Date.now();
+  if (store.length > 0 && timestamp <= store[0].timestamp) {
+    timestamp = store[0].timestamp + 1;
+  }
+  const snap: Snapshot = { config, timestamp, trigger };
+  store.unshift(snap);
+  if (store.length > MAX_SNAPSHOTS) {
+    store.length = MAX_SNAPSHOTS;
+  }
+  persist(snap);
+}
+
 export function listSnapshots(): readonly Snapshot[] {
+  hydrate();
   return store;
 }
 
 export function getSnapshot(index: number): Snapshot | undefined {
+  hydrate();
   return store[index];
 }
 
 export function clearSnapshots(): void {
   store.length = 0;
+  // Mark hydrated so a follow-up read does NOT pull the persisted set back in.
+  // "Clear" that refills itself from disk on the next call would be the wrong
+  // reading of the name. This empties the in-memory ring only; persisted files
+  // are left alone, and a fresh process will load them again.
+  hydrated = true;
 }

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -1393,6 +1393,70 @@ describe("api", () => {
     });
   });
 
+  describe("request body encoding", () => {
+    async function captureBody(call: (a: typeof import("../api.js")) => Promise<unknown>) {
+      const api = await import("../api.js");
+      let sent: any;
+      globalThis.fetch = vi.fn(async (_url: any, opts: any) => {
+        sent = opts.body;
+        return new Response("{}", { status: 200 });
+      }) as any;
+      await call(api);
+      return sent;
+    }
+
+    // A config write's body is a JSON *value*, so a string has to be
+    // JSON-encoded. Sending it bare made Caddy answer
+    //   500 {"error":"decoding request body: invalid character 'x' ..."}
+    // which broke every string-valued write: caddy_tls set_email /
+    // set_acme_ca / set_acme_profile, and caddy_config_set with a string.
+    it.each([
+      ["configPatch", (a: typeof import("../api.js")) => a.configPatch("apps/tls/.../email", "x@y.test")],
+      ["configPost", (a: typeof import("../api.js")) => a.configPost("apps/tls/.../email", "x@y.test")],
+      ["configPut", (a: typeof import("../api.js")) => a.configPut("apps/tls/.../email", "x@y.test")],
+    ])("%s JSON-encodes a string value", async (_label, call) => {
+      const sent = await captureBody(call);
+      expect(sent).toBe('"x@y.test"');
+      expect(JSON.parse(sent)).toBe("x@y.test");
+    });
+
+    it("configByIdSet JSON-encodes a string value", async () => {
+      const sent = await captureBody((a) => a.configByIdSet("my-id", "some-string", "PATCH"));
+      expect(sent).toBe('"some-string"');
+    });
+
+    it("still JSON-encodes objects", async () => {
+      const sent = await captureBody((a) => a.configPatch("apps/tls", { automation: {} }));
+      expect(JSON.parse(sent)).toEqual({ automation: {} });
+    });
+
+    // The other side of the same switch: /load and /adapt take a raw document,
+    // so a string body must go out untouched. Double-encoding a Caddyfile here
+    // would break both endpoints.
+    it("sends a Caddyfile to /load verbatim, not JSON-encoded", async () => {
+      const caddyfile = ':8080 {\n  respond "hi"\n}\n';
+      const sent = await captureBody((a) => a.loadConfig(caddyfile, "text/caddyfile"));
+      expect(sent).toBe(caddyfile);
+    });
+
+    it("sends a JSON config string to /load verbatim", async () => {
+      const raw = '{"apps":{"http":{}}}';
+      const sent = await captureBody((a) => a.loadConfig(raw, "application/json"));
+      expect(sent).toBe(raw);
+    });
+
+    it("sends the adapt payload verbatim", async () => {
+      const caddyfile = ":8080 {\n}\n";
+      const sent = await captureBody((a) => a.adapt(caddyfile));
+      expect(sent).toBe(caddyfile);
+    });
+
+    it("still JSON-encodes an object passed to /load", async () => {
+      const sent = await captureBody((a) => a.loadConfig({ apps: { http: {} } }, "application/json"));
+      expect(JSON.parse(sent)).toEqual({ apps: { http: {} } });
+    });
+  });
+
   describe("403 origin rejection", () => {
     // This branch is the whole reason requests work against a stock Caddy:
     // Node's fetch always sends Sec-Fetch-Mode, which makes Caddy enforce its

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -1392,4 +1392,103 @@ describe("api", () => {
       expect(called).toBe(0);
     });
   });
+
+  describe("unix socket admin endpoint", () => {
+    // A missing socket path is the cheapest way to prove the request was routed
+    // to node:http rather than fetch: the global fetch stub stays untouched and
+    // the error comes back in the socket-specific shape.
+    it.each([
+      ["URL form", `unix://${process.platform === "win32" ? "/nope" : "/tmp/caddy-mcp-does-not-exist.sock"}`],
+      [
+        "Caddy network-address form",
+        `unix/${process.platform === "win32" ? "/nope" : "/tmp/caddy-mcp-does-not-exist.sock"}`,
+      ],
+    ])("routes %s away from fetch entirely", async (_label, adminUrl) => {
+      const api = await import("../api.js");
+      process.env.CADDY_ADMIN_URL = adminUrl;
+      let fetchCalls = 0;
+      globalThis.fetch = vi.fn(async () => {
+        fetchCalls++;
+        return new Response("{}", { status: 200 });
+      }) as any;
+
+      const res = await api.configGet();
+      expect(res.ok).toBe(false);
+      // Never fell through to the TCP transport.
+      expect(fetchCalls).toBe(0);
+    });
+
+    // POSIX-only: a nonexistent path reliably yields ENOENT there. The Windows
+    // named-pipe equivalent does not survive the unix:// URL form, so gating
+    // keeps the assertion exact instead of loosening it to match both branches.
+    it.skipIf(process.platform === "win32")(
+      "reports a missing socket distinctly from a refused connection",
+      async () => {
+        const api = await import("../api.js");
+        const sock = "/tmp/caddy-mcp-does-not-exist.sock";
+        process.env.CADDY_ADMIN_URL = `unix://${sock}`;
+        globalThis.fetch = vi.fn(async () => new Response("{}", { status: 200 })) as any;
+
+        const res = await api.configGet();
+        expect(res.ok).toBe(false);
+        expect(res.status).toBe(0);
+        // Must be the socket-specific message, NOT the generic
+        // "Cannot connect ... is Caddy running?" a refused connection gets --
+        // the two point at different fixes (wrong path vs Caddy not running).
+        expect(res.error).toContain("No socket at");
+        expect(res.error).toContain(sock);
+        expect(res.error).not.toContain("is Caddy running?");
+      },
+    );
+
+    // The real round-trip. AF_UNIX is a POSIX deployment concern and Windows
+    // uses named pipes with different semantics, so it runs where it matters.
+    describe.skipIf(process.platform === "win32")("against a live unix socket", () => {
+      it("completes a request and sends NO Origin or Sec-Fetch-Mode header", async () => {
+        const { createServer } = await import("node:http");
+        const { tmpdir } = await import("node:os");
+        const { join } = await import("node:path");
+        const { unlinkSync, existsSync } = await import("node:fs");
+
+        const sockPath = join(tmpdir(), `caddy-mcp-test-${process.pid}.sock`);
+        if (existsSync(sockPath)) unlinkSync(sockPath);
+
+        let seenOrigin: string | undefined = "unset";
+        let seenSecFetch: string | undefined = "unset";
+        const srv = createServer((req, res) => {
+          seenOrigin = req.headers.origin;
+          seenSecFetch = req.headers["sec-fetch-mode"] as string | undefined;
+          res.setHeader("ETag", '"/config/ abc123"');
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ apps: { http: {} } }));
+        });
+        await new Promise<void>((ok) => srv.listen(sockPath, ok));
+
+        try {
+          const api = await import("../api.js");
+          process.env.CADDY_ADMIN_URL = `unix://${sockPath}`;
+          let fetchCalls = 0;
+          globalThis.fetch = vi.fn(async () => {
+            fetchCalls++;
+            return new Response("{}", { status: 200 });
+          }) as any;
+
+          const res = await api.configGet<{ apps?: unknown }>();
+          expect(res.ok).toBe(true);
+          expect(res.data?.apps).toBeDefined();
+          expect(fetchCalls).toBe(0);
+
+          // The security-relevant assertion. Caddy builds NO default origin
+          // allowlist for a unix admin listener, and only runs its origin check
+          // when the request carries Origin or Sec-Fetch-Mode -- so sending
+          // either would opt into a check against an empty list and 403.
+          expect(seenOrigin).toBeUndefined();
+          expect(seenSecFetch).toBeUndefined();
+        } finally {
+          await new Promise<void>((ok) => srv.close(() => ok()));
+          if (existsSync(sockPath)) unlinkSync(sockPath);
+        }
+      });
+    });
+  });
 });

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -1393,6 +1393,92 @@ describe("api", () => {
     });
   });
 
+  describe("403 origin rejection", () => {
+    // This branch is the whole reason requests work against a stock Caddy:
+    // Node's fetch always sends Sec-Fetch-Mode, which makes Caddy enforce its
+    // admin origin allowlist. When that still fails, this message is the only
+    // thing pointing the operator at the cause.
+    it("explains the admin origin allowlist on a 403 naming an origin", async () => {
+      const api = await import("../api.js");
+      globalThis.fetch = vi.fn(
+        async () => new Response(`{"error":"client is not allowed to access from origin ''"}`, { status: 403 }),
+      ) as any;
+
+      const res = await api.configGet();
+      expect(res.ok).toBe(false);
+      expect(res.status).toBe(403);
+      // Caddy's own body is preserved ahead of our explanation.
+      expect(res.error).toContain("not allowed to access from origin");
+      expect(res.error).toContain("CADDY_ADMIN_URL");
+      expect(res.error).toContain("admin.origins");
+    });
+
+    it("leaves an unrelated 403 body alone", async () => {
+      const api = await import("../api.js");
+      globalThis.fetch = vi.fn(async () => new Response("forbidden: bad token", { status: 403 })) as any;
+
+      const res = await api.configGet();
+      expect(res.error).toBe("forbidden: bad token");
+      expect(res.error).not.toContain("admin.origins");
+    });
+  });
+
+  describe("malformed unix socket URLs", () => {
+    // Both of these previously fell through to fetch and surfaced
+    // "Cannot connect to Caddy admin API at null", naming neither the socket
+    // nor the mistake.
+    it.each([
+      ["single slash after unix:", "unix:/run/caddy-admin.sock"],
+      ["relative path", "unix://relative.sock"],
+      ["bare scheme", "unix://"],
+    ])("rejects %s with actionable guidance and never hits fetch", async (_label, adminUrl) => {
+      const api = await import("../api.js");
+      process.env.CADDY_ADMIN_URL = adminUrl;
+      let fetchCalls = 0;
+      globalThis.fetch = vi.fn(async () => {
+        fetchCalls++;
+        return new Response("{}", { status: 200 });
+      }) as any;
+
+      const res = await api.configGet();
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain("looks like a unix socket address");
+      expect(res.error).toContain("unix:///absolute/path.sock");
+      expect(fetchCalls).toBe(0);
+    });
+
+    it("does not retry a malformed URL despite status 0", async () => {
+      // status 0 is normally treated as a transient failure and replayed; a
+      // static config mistake must not burn the retry budget.
+      process.env.CADDY_MAX_RETRIES = "3";
+      process.env.CADDY_ADMIN_URL = "unix:/run/caddy-admin.sock";
+      const api = await import("../api.js");
+      let fetchCalls = 0;
+      globalThis.fetch = vi.fn(async () => {
+        fetchCalls++;
+        return new Response("{}", { status: 200 });
+      }) as any;
+
+      const res = await api.configGet();
+      expect(res.ok).toBe(false);
+      expect(fetchCalls).toBe(0);
+    });
+
+    it("does not mistake a real host starting with 'unix' for a socket", async () => {
+      process.env.CADDY_ADMIN_URL = "http://unix.example.com:2019";
+      const api = await import("../api.js");
+      let calledUrl = "";
+      globalThis.fetch = vi.fn(async (url: any) => {
+        calledUrl = url.toString();
+        return new Response("{}", { status: 200 });
+      }) as any;
+
+      const res = await api.configGet();
+      expect(res.ok).toBe(true);
+      expect(calledUrl).toContain("unix.example.com:2019");
+    });
+  });
+
   describe("unix socket admin endpoint", () => {
     // A missing socket path is the cheapest way to prove the request was routed
     // to node:http rather than fetch: the global fetch stub stays untouched and
@@ -1443,52 +1529,212 @@ describe("api", () => {
 
     // The real round-trip. AF_UNIX is a POSIX deployment concern and Windows
     // uses named pipes with different semantics, so it runs where it matters.
+    // The unix transport is the least-exercised code in this module, so these
+    // drive a REAL unix socket rather than a mock. AF_UNIX is a POSIX
+    // deployment concern and Caddy has no Windows named-pipe admin listener
+    // (its admin address parser only knows unix/unixgram/unixpacket and fd),
+    // so there is nothing to gain from a named-pipe variant here.
     describe.skipIf(process.platform === "win32")("against a live unix socket", () => {
-      it("completes a request and sends NO Origin or Sec-Fetch-Mode header", async () => {
+      interface Captured {
+        method?: string;
+        url?: string;
+        headers: Record<string, string | string[] | undefined>;
+        body: string;
+      }
+
+      /**
+       * Spin a unix-socket HTTP server that replies with `reply`, capturing the
+       * request. A `reply` returning null accepts the connection and never
+       * responds, which is what the timeout case needs.
+       */
+      async function withSocketServer(
+        reply: (req: Captured) => { status?: number; headers?: Record<string, string>; body?: string } | null,
+        run: (captured: Captured) => Promise<void>,
+      ) {
         const { createServer } = await import("node:http");
+        const { mkdtempSync, rmSync } = await import("node:fs");
         const { tmpdir } = await import("node:os");
         const { join } = await import("node:path");
-        const { unlinkSync, existsSync } = await import("node:fs");
 
-        const sockPath = join(tmpdir(), `caddy-mcp-test-${process.pid}.sock`);
-        if (existsSync(sockPath)) unlinkSync(sockPath);
+        // mkdtemp keeps the path short -- POSIX caps sun_path around 104 bytes.
+        const dir = mkdtempSync(join(tmpdir(), "cmcp-"));
+        const sockPath = join(dir, "s.sock");
+        const captured: Captured = { headers: {}, body: "" };
 
-        let seenOrigin: string | undefined = "unset";
-        let seenSecFetch: string | undefined = "unset";
         const srv = createServer((req, res) => {
-          seenOrigin = req.headers.origin;
-          seenSecFetch = req.headers["sec-fetch-mode"] as string | undefined;
-          res.setHeader("ETag", '"/config/ abc123"');
-          res.setHeader("Content-Type", "application/json");
-          res.end(JSON.stringify({ apps: { http: {} } }));
+          captured.method = req.method;
+          captured.url = req.url;
+          captured.headers = req.headers;
+          const chunks: Buffer[] = [];
+          req.on("data", (c: Buffer) => chunks.push(c));
+          req.on("end", () => {
+            captured.body = Buffer.concat(chunks).toString("utf8");
+            const r = reply(captured);
+            if (r === null) return; // hang deliberately -- the timeout case
+            for (const [k, v] of Object.entries(r.headers ?? {})) res.setHeader(k, v);
+            res.statusCode = r.status ?? 200;
+            res.end(r.body ?? "");
+          });
         });
         await new Promise<void>((ok) => srv.listen(sockPath, ok));
 
         try {
-          const api = await import("../api.js");
           process.env.CADDY_ADMIN_URL = `unix://${sockPath}`;
-          let fetchCalls = 0;
-          globalThis.fetch = vi.fn(async () => {
-            fetchCalls++;
-            return new Response("{}", { status: 200 });
-          }) as any;
-
-          const res = await api.configGet<{ apps?: unknown }>();
-          expect(res.ok).toBe(true);
-          expect(res.data?.apps).toBeDefined();
-          expect(fetchCalls).toBe(0);
-
-          // The security-relevant assertion. Caddy builds NO default origin
-          // allowlist for a unix admin listener, and only runs its origin check
-          // when the request carries Origin or Sec-Fetch-Mode -- so sending
-          // either would opt into a check against an empty list and 403.
-          expect(seenOrigin).toBeUndefined();
-          expect(seenSecFetch).toBeUndefined();
+          await run(captured);
         } finally {
           await new Promise<void>((ok) => srv.close(() => ok()));
-          if (existsSync(sockPath)) unlinkSync(sockPath);
+          rmSync(dir, { recursive: true, force: true });
         }
+      }
+
+      /** Fetch stub that fails loudly if the unix path ever falls through to TCP. */
+      function forbidFetch() {
+        globalThis.fetch = vi.fn(async () => {
+          throw new Error("fetch must not be used when CADDY_ADMIN_URL is a unix socket");
+        }) as any;
+      }
+
+      it("completes a GET and sends NO Origin or Sec-Fetch-Mode header", async () => {
+        await withSocketServer(
+          () => ({ headers: { ETag: '"/config/ abc123"' }, body: JSON.stringify({ apps: { http: {} } }) }),
+          async (captured) => {
+            const api = await import("../api.js");
+            forbidFetch();
+
+            const res = await api.configGet<{ apps?: unknown }>();
+            expect(res.ok).toBe(true);
+            expect(res.data?.apps).toBeDefined();
+
+            // The security-relevant assertion. Caddy builds NO default origin
+            // allowlist for a unix admin listener and only runs its origin
+            // check when the request carries Origin or Sec-Fetch-Mode -- so
+            // sending either opts into a check against an empty list and 403s.
+            expect(captured.headers.origin).toBeUndefined();
+            expect(captured.headers["sec-fetch-mode"]).toBeUndefined();
+          },
+        );
       });
+
+      it("sends a write request with its body and content type", async () => {
+        // Writes are the point of this server, and req.write() plus chunked
+        // encoding is a different path from the bodyless GET above.
+        await withSocketServer(
+          () => ({ status: 200, body: "" }),
+          async (captured) => {
+            const api = await import("../api.js");
+            forbidFetch();
+
+            const res = await api.configPost("apps/http/servers/srv0/routes", { handle: [{ handler: "static" }] });
+            expect(res.ok).toBe(true);
+            expect(captured.method).toBe("POST");
+            expect(captured.url).toBe("/config/apps/http/servers/srv0/routes");
+            expect(captured.headers["content-type"]).toBe("application/json");
+            expect(JSON.parse(captured.body)).toEqual({ handle: [{ handler: "static" }] });
+          },
+        );
+      });
+
+      it("still sends Authorization when CADDY_API_TOKEN is set", async () => {
+        // getHeaders returns early for the unix path; that early return sits
+        // AFTER the token block. If it ever moves up, auth silently vanishes
+        // on socket endpoints and only a user would notice.
+        await withSocketServer(
+          () => ({ body: "{}" }),
+          async (captured) => {
+            process.env.CADDY_API_TOKEN = "sock-token";
+            const api = await import("../api.js");
+            forbidFetch();
+
+            await api.configGet();
+            expect(captured.headers.authorization).toBe("Bearer sock-token");
+            expect(captured.headers.origin).toBeUndefined();
+          },
+        );
+      });
+
+      it("maps a non-2xx socket response to the same error shape as TCP", async () => {
+        // `ok` is hand-rolled here (status >= 200 && < 300) where the fetch
+        // path gets res.ok for free.
+        await withSocketServer(
+          () => ({ status: 404, body: "key does not exist" }),
+          async () => {
+            const api = await import("../api.js");
+            forbidFetch();
+
+            const res = await api.configGet("apps/http/servers/nope");
+            expect(res.ok).toBe(false);
+            expect(res.status).toBe(404);
+            expect(res.error).toBe("key does not exist");
+          },
+        );
+      });
+
+      it("returns an empty-body 2xx as ok with no data", async () => {
+        await withSocketServer(
+          () => ({ status: 200, body: "" }),
+          async () => {
+            const api = await import("../api.js");
+            forbidFetch();
+
+            const res = await api.configGet();
+            expect(res.ok).toBe(true);
+            expect(res.data).toBeUndefined();
+          },
+        );
+      });
+
+      it("explains enforce_origin, not CADDY_ADMIN_URL, on a 403 over a socket", async () => {
+        // The TCP advice ("point CADDY_ADMIN_URL at the allowed origin") is
+        // actively wrong here -- it would move the operator off the socket.
+        await withSocketServer(
+          () => ({ status: 403, body: `{"error":"client is not allowed to access from origin ''"}` }),
+          async () => {
+            const api = await import("../api.js");
+            forbidFetch();
+
+            const res = await api.configGet();
+            expect(res.status).toBe(403);
+            expect(res.error).toContain("enforce_origin");
+            expect(res.error).not.toContain("Set CADDY_ADMIN_URL to the exact origin");
+          },
+        );
+      });
+
+      it("captures an ETag and replays it as If-Match on the next write", async () => {
+        await withSocketServer(
+          (req) => (req.method === "GET" ? { headers: { ETag: '"/config/apps 1234"' }, body: "{}" } : { body: "" }),
+          async (captured) => {
+            const api = await import("../api.js");
+            forbidFetch();
+
+            await api.configGet("apps");
+            const res = await api.configPatch("apps", { http: {} });
+            expect(res.ok).toBe(true);
+            expect(captured.headers["if-match"]).toBe('"/config/apps 1234"');
+          },
+        );
+      });
+
+      it("times out on an absolute deadline rather than an inactivity timer", async () => {
+        // AbortSignal.timeout, not req.setTimeout. A server that accepts and
+        // never replies must still abort, and the AbortError must classify as
+        // a timeout rather than falling through to the generic transport case.
+        await withSocketServer(
+          () => null,
+          async () => {
+            process.env.CADDY_TIMEOUT = "150";
+            const api = await import("../api.js");
+            forbidFetch();
+            const started = Date.now();
+
+            const res = await api.configGet();
+            expect(res.ok).toBe(false);
+            expect(res.status).toBe(0);
+            expect(res.error).toContain("timed out after 150ms");
+            expect(Date.now() - started).toBeLessThan(5000);
+          },
+        );
+      }, 15000);
     });
   });
 });

--- a/src/tests/handlers.test.ts
+++ b/src/tests/handlers.test.ts
@@ -2500,6 +2500,84 @@ describe("tool handler behavior", () => {
       expect(snaps[0]?.config).toEqual({ good: true });
     });
 
+    // persist() sanitizes the trigger into the filename with [^\w-] -> "_", and
+    // hydrate() parses it back with ([\w-]+). If those two ever drift, snapshots
+    // write files that can never be read back -- silent loss of the rollback
+    // target, which is the one thing this feature exists to protect.
+    it.each([
+      ["caddy_load", "caddy_load"],
+      ["caddy_revert", "caddy_revert"],
+      ["manual", "manual"],
+      ["with spaces", "with_spaces"],
+      ["slash/and:colon", "slash_and_colon"],
+    ])("round-trips the trigger %s through the filename", async (trigger, expected) => {
+      const snapshots = await import("../snapshots.js");
+      snapshots.clearSnapshots();
+      snapshots.saveSnapshot({ a: 1 }, trigger);
+
+      vi.resetModules();
+      const restarted = await import("../snapshots.js");
+      const snaps = restarted.listSnapshots();
+      expect(snaps).toHaveLength(1);
+      expect(snaps[0]?.trigger).toBe(expected);
+    });
+
+    it("ignores files that are not snapshots", async () => {
+      // Pointing the dir at an existing or shared location is realistic.
+      const { writeFileSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const snapshots = await import("../snapshots.js");
+      snapshots.clearSnapshots();
+      snapshots.saveSnapshot({ real: true }, "manual");
+
+      writeFileSync(join(tmp as string, "notes.txt"), "hello", "utf-8");
+      writeFileSync(join(tmp as string, "config.json"), '{"not":"a snapshot"}', "utf-8");
+      writeFileSync(join(tmp as string, "snapshot-nope-manual.json"), "{}", "utf-8");
+
+      vi.resetModules();
+      const restarted = await import("../snapshots.js");
+      const snaps = restarted.listSnapshots();
+      expect(snaps).toHaveLength(1);
+      expect(snaps[0]?.config).toEqual({ real: true });
+    });
+
+    it("reads only the newest MAX_SNAPSHOTS when more files exist on disk", async () => {
+      // persist() prunes on write, but a directory can still hold more (older
+      // version, external population). This is the read-side bound.
+      const { writeFileSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      for (let i = 0; i < 25; i++) {
+        // Fixed-width timestamps so the filename sort matches a numeric one.
+        writeFileSync(
+          join(tmp as string, `snapshot-17000000000${String(i).padStart(2, "0")}-manual.json`),
+          `{"i":${i}}`,
+          "utf-8",
+        );
+      }
+
+      vi.resetModules();
+      const snapshots = await import("../snapshots.js");
+      const snaps = snapshots.listSnapshots();
+      expect(snaps).toHaveLength(10);
+      // Newest first: i=24 down to i=15.
+      expect((snaps[0]?.config as { i: number }).i).toBe(24);
+      expect((snaps[9]?.config as { i: number }).i).toBe(15);
+    });
+
+    it("clearSnapshots empties the ring without repopulating from disk", async () => {
+      const snapshots = await import("../snapshots.js");
+      snapshots.clearSnapshots();
+      snapshots.saveSnapshot({ a: 1 }, "manual");
+      expect(snapshots.listSnapshots()).toHaveLength(1);
+
+      snapshots.clearSnapshots();
+      // The persisted file is still there, but a clear must stay cleared --
+      // a "clear" that refills itself on the next read would be the wrong
+      // reading of the name.
+      expect(snapshots.listSnapshots()).toHaveLength(0);
+      expect(snapshots.getSnapshot(0)).toBeUndefined();
+    });
+
     it("falls back to memory-only when the directory cannot be written", async () => {
       // A path whose parent is a FILE, so mkdirSync fails. The save must still
       // land in the in-memory ring.

--- a/src/tests/handlers.test.ts
+++ b/src/tests/handlers.test.ts
@@ -819,6 +819,24 @@ describe("tool handler behavior", () => {
       handler = getToolHandler(mockServer, "caddy_tls");
     });
 
+    /**
+     * Mock configPatch the way real Caddy actually behaves on the fallback
+     * path: a PATCH of the issuer SUB-path 404s when that key is absent, while
+     * a PATCH of the whole apps/tls object succeeds because apps/tls exists.
+     *
+     * Both writes go through configPatch now, so a blanket
+     * `configPatch.mockResolvedValue(err(...))` would fail the merge too and
+     * silently invert what these tests claim to prove.
+     */
+    function subpathPatchFails(subpathError: any = err(404, "key does not exist")) {
+      api.configPatch.mockImplementation(async (path: string) => (path === "apps/tls" ? ok() : subpathError));
+    }
+
+    /** The merge write: the configPatch call targeting apps/tls as a whole. */
+    function mergeCall(): any[] | undefined {
+      return api.configPatch.mock.calls.find((c: any[]) => c[0] === "apps/tls");
+    }
+
     it("uses PATCH when path already exists (no GET, no POST/PUT)", async () => {
       api.configPatch.mockResolvedValue(ok());
 
@@ -866,7 +884,11 @@ describe("tool handler behavior", () => {
     });
 
     // Branch 2: shape OK — deep-merge into existing config and PUT it back.
-    it("PATCH fails + apps/tls exists with expected shape -> PUTs merged config (preserves siblings)", async () => {
+    // PATCH, never PUT. Caddy's PUT on a non-array key is strictly-create and
+    // returns 409 "key already exists: tls" whenever apps/tls is present --
+    // which is precisely the condition this branch runs under. Verified against
+    // a live Caddy 2.11.4.
+    it("PATCH fails + apps/tls exists with expected shape -> PATCHes merged config (preserves siblings)", async () => {
       const existing = {
         automation: {
           policies: [{ issuers: [{ module: "acme", email: "old@example.com" }] }],
@@ -874,20 +896,21 @@ describe("tool handler behavior", () => {
         },
         certificate_authorities: { custom: { name: "internal" } },
       };
-      api.configPatch.mockResolvedValue(err(500, "key does not exist"));
+      subpathPatchFails();
       api.configGet.mockResolvedValue(ok(existing));
-      api.configPut.mockResolvedValue(ok());
 
       const result = await handler({ action: "set_acme_ca", ca: "https://new.example.com/dir" });
 
-      expect(api.configPut).toHaveBeenCalledTimes(1);
-      const [putPath, putBody] = api.configPut.mock.calls[0];
-      expect(putPath).toBe("apps/tls");
+      // The merge must NOT go out as a PUT -- that is the 409.
+      expect(api.configPut).not.toHaveBeenCalled();
+      const call = mergeCall();
+      expect(call, "expected a configPatch to apps/tls").toBeDefined();
+      const mergedBody = (call as any[])[1];
       // Sibling fields preserved
-      expect(putBody.automation.on_demand).toEqual({ rate_limit: { interval: "10s", burst: 5 } });
-      expect(putBody.certificate_authorities).toEqual({ custom: { name: "internal" } });
+      expect(mergedBody.automation.on_demand).toEqual({ rate_limit: { interval: "10s", burst: 5 } });
+      expect(mergedBody.certificate_authorities).toEqual({ custom: { name: "internal" } });
       // Existing email kept, ca added
-      expect(putBody.automation.policies[0].issuers[0]).toEqual({
+      expect(mergedBody.automation.policies[0].issuers[0]).toEqual({
         module: "acme",
         email: "old@example.com",
         ca: "https://new.example.com/dir",
@@ -905,14 +928,13 @@ describe("tool handler behavior", () => {
           policies: [{ issuers: [{ module: "acme", email: "old@example.com", ca: "https://old.example.com" }] }],
         },
       };
-      api.configPatch.mockResolvedValue(err(500, "key does not exist"));
+      subpathPatchFails();
       api.configGet.mockResolvedValue(ok(existing));
-      api.configPut.mockResolvedValue(ok());
 
       await handler({ action: "set_email", email: "new@example.com" });
 
-      const [, putBody] = api.configPut.mock.calls[0];
-      expect(putBody.automation.policies[0].issuers[0]).toEqual({
+      const mergedBody = (mergeCall() as any[])[1];
+      expect(mergedBody.automation.policies[0].issuers[0]).toEqual({
         module: "acme",
         email: "new@example.com",
         ca: "https://old.example.com",
@@ -1010,16 +1032,17 @@ describe("tool handler behavior", () => {
       expect(result.content[0].text).toContain("post-fail");
     });
 
-    it("PATCH fails + shape OK + PUT fails -> surfaces both PATCH and PUT errors", async () => {
+    it("PATCH fails + shape OK + merge write fails -> surfaces both errors", async () => {
+      // Both writes fail here, so a blanket mock is what we actually want.
       api.configPatch.mockResolvedValue(err(500, "patch-fail"));
       api.configGet.mockResolvedValue(ok({ automation: { policies: [{ issuers: [{ module: "acme" }] }] } }));
-      api.configPut.mockResolvedValue(err(500, "put-fail"));
 
       const result = await handler({ action: "set_email", email: "test@example.com" });
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("patch-fail");
-      expect(result.content[0].text).toContain("put-fail");
+      expect(result.content[0].text).toContain("PATCH apps/tls fallback");
+      expect(api.configPut).not.toHaveBeenCalled();
     });
 
     it("returns error when email is missing for set_email", async () => {
@@ -1069,20 +1092,23 @@ describe("tool handler behavior", () => {
       expect(result.isError).toBeFalsy();
     });
 
+    // This is the NORMAL path for set_acme_profile, not an edge case: a fresh
+    // ACME issuer carries no `profile` key, so the sub-path PATCH 404s and the
+    // fallback runs every time. Confirmed against a live Caddy 2.11.4.
     it("set_acme_profile merges into an existing issuer without dropping siblings", async () => {
-      api.configPatch.mockResolvedValue(err(500, "key does not exist"));
+      subpathPatchFails();
       api.configGet.mockResolvedValue(
         ok({
           automation: { policies: [{ issuers: [{ module: "acme", email: "keep@example.com" }] }] },
           certificates: { load_files: [{ certificate: "/c.pem" }] },
         }),
       );
-      api.configPut.mockResolvedValue(ok());
 
-      await handler({ action: "set_acme_profile", profile: "shortlived" });
+      const result = await handler({ action: "set_acme_profile", profile: "shortlived" });
 
-      const [path, body] = api.configPut.mock.calls[0];
-      expect(path).toBe("apps/tls");
+      expect(result.isError).toBeFalsy();
+      expect(api.configPut).not.toHaveBeenCalled();
+      const body = (mergeCall() as any[])[1];
       expect(body.automation.policies[0].issuers[0]).toEqual({
         module: "acme",
         email: "keep@example.com",

--- a/src/tests/handlers.test.ts
+++ b/src/tests/handlers.test.ts
@@ -1044,6 +1044,100 @@ describe("tool handler behavior", () => {
       expect(api.configGet).toHaveBeenCalledWith("apps/tls");
       expect(result.content[0].text).toContain("automation");
     });
+
+    // ACME profiles landed in Caddy 2.10; the issuer field is `profile`.
+    it("set_acme_profile PATCHes the issuer's profile field", async () => {
+      api.configPatch.mockResolvedValue(ok());
+
+      const result = await handler({ action: "set_acme_profile", profile: "shortlived" });
+
+      expect(api.configPatch).toHaveBeenCalledWith("apps/tls/automation/policies/0/issuers/0/profile", "shortlived");
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain("shortlived");
+    });
+
+    it("set_acme_profile falls back to a fresh apps/tls carrying the profile", async () => {
+      api.configPatch.mockResolvedValue(err(500, "key does not exist"));
+      api.configGet.mockResolvedValue(err(404, "not found"));
+      api.configPost.mockResolvedValue(ok());
+
+      const result = await handler({ action: "set_acme_profile", profile: "shortlived" });
+
+      expect(api.configPost).toHaveBeenCalledWith("apps/tls", {
+        automation: { policies: [{ issuers: [{ module: "acme", profile: "shortlived" }] }] },
+      });
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("set_acme_profile merges into an existing issuer without dropping siblings", async () => {
+      api.configPatch.mockResolvedValue(err(500, "key does not exist"));
+      api.configGet.mockResolvedValue(
+        ok({
+          automation: { policies: [{ issuers: [{ module: "acme", email: "keep@example.com" }] }] },
+          certificates: { load_files: [{ certificate: "/c.pem" }] },
+        }),
+      );
+      api.configPut.mockResolvedValue(ok());
+
+      await handler({ action: "set_acme_profile", profile: "shortlived" });
+
+      const [path, body] = api.configPut.mock.calls[0];
+      expect(path).toBe("apps/tls");
+      expect(body.automation.policies[0].issuers[0]).toEqual({
+        module: "acme",
+        email: "keep@example.com",
+        profile: "shortlived",
+      });
+      // The sibling key must survive the merge.
+      expect(body.certificates).toEqual({ load_files: [{ certificate: "/c.pem" }] });
+    });
+
+    it("returns error when profile is missing for set_acme_profile", async () => {
+      const result = await handler({ action: "set_acme_profile" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("profile is required");
+      expect(api.configPatch).not.toHaveBeenCalled();
+    });
+
+    it("ech_status reads apps/tls/ech and never writes", async () => {
+      api.configGet.mockResolvedValue(ok({ publication: [{ domains: ["example.com"] }] }));
+
+      const result = await handler({ action: "ech_status" });
+
+      expect(api.configGet).toHaveBeenCalledWith("apps/tls/ech");
+      expect(api.configPatch).not.toHaveBeenCalled();
+      expect(api.configPost).not.toHaveBeenCalled();
+      expect(api.configPut).not.toHaveBeenCalled();
+      expect(result.content[0].text).toContain("example.com");
+    });
+
+    // ECH is rarely enabled, so this is the ordinary answer, not a failure.
+    it("ech_status reports 'not configured' rather than a 404 error", async () => {
+      api.configGet.mockResolvedValue(err(404, "not found"));
+
+      const result = await handler({ action: "ech_status" });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain("not configured");
+    });
+
+    it("ech_status treats an empty body as 'not configured' too", async () => {
+      api.configGet.mockResolvedValue(ok(null));
+
+      const result = await handler({ action: "ech_status" });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain("not configured");
+    });
+
+    it("ech_status still surfaces a real read failure as an error", async () => {
+      api.configGet.mockResolvedValue(err(500, "internal error"));
+
+      const result = await handler({ action: "ech_status" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("internal error");
+    });
   });
 
   // ─── caddy_adapt ──────────────────────────────────────────────────────
@@ -2298,6 +2392,128 @@ describe("tool handler behavior", () => {
       expect((snaps[0]?.config as { generation: number }).generation).toBe(10);
       expect(snaps[9]?.trigger).toBe("seed-1");
       expect(snaps.some((s) => s.trigger === "seed-0")).toBe(false);
+    });
+  });
+
+  describe("snapshot persistence (CADDY_MCP_SNAPSHOT_DIR)", () => {
+    const savedDir = process.env.CADDY_MCP_SNAPSHOT_DIR;
+    let tmp: string | undefined;
+
+    beforeEach(async () => {
+      const { mkdtempSync } = await import("node:fs");
+      const { tmpdir } = await import("node:os");
+      const { join } = await import("node:path");
+      tmp = mkdtempSync(join(tmpdir(), "caddy-mcp-snap-"));
+      process.env.CADDY_MCP_SNAPSHOT_DIR = tmp;
+    });
+
+    afterEach(async () => {
+      const { rmSync } = await import("node:fs");
+      if (tmp) rmSync(tmp, { recursive: true, force: true });
+      if (savedDir !== undefined) process.env.CADDY_MCP_SNAPSHOT_DIR = savedDir;
+      else delete process.env.CADDY_MCP_SNAPSHOT_DIR;
+      vi.resetModules();
+    });
+
+    it("writes a file per snapshot and rehydrates it in a fresh module instance", async () => {
+      const { readdirSync } = await import("node:fs");
+      const first = await import("../snapshots.js");
+      first.clearSnapshots();
+      first.saveSnapshot({ apps: { http: {} } }, "caddy_load");
+      first.saveSnapshot({ apps: { tls: {} } }, "manual");
+
+      expect(readdirSync(tmp as string).filter((f) => f.endsWith(".json"))).toHaveLength(2);
+
+      // A fresh module registry stands in for a server restart: the ring starts
+      // empty in memory and must come back from disk, newest first.
+      vi.resetModules();
+      const restarted = await import("../snapshots.js");
+      const snaps = restarted.listSnapshots();
+      expect(snaps).toHaveLength(2);
+      expect(snaps[0]?.trigger).toBe("manual");
+      expect(snaps[1]?.trigger).toBe("caddy_load");
+      expect(restarted.getSnapshot(1)?.config).toEqual({ apps: { http: {} } });
+    });
+
+    it("prunes persisted files beyond the 10-deep ring", async () => {
+      const { readdirSync } = await import("node:fs");
+      const snapshots = await import("../snapshots.js");
+      snapshots.clearSnapshots();
+      for (let i = 0; i < 13; i++) snapshots.saveSnapshot({ generation: i }, `seed-${i}`);
+      expect(readdirSync(tmp as string).filter((f) => f.endsWith(".json"))).toHaveLength(10);
+    });
+
+    it("keeps distinct files for snapshots captured in the same millisecond", async () => {
+      const { readdirSync } = await import("node:fs");
+      const snapshots = await import("../snapshots.js");
+      snapshots.clearSnapshots();
+      // Tight loop -- several of these land on the same Date.now() value.
+      for (let i = 0; i < 5; i++) snapshots.saveSnapshot({ generation: i }, "caddy_load");
+      expect(readdirSync(tmp as string).filter((f) => f.endsWith(".json"))).toHaveLength(5);
+      expect(snapshots.listSnapshots()).toHaveLength(5);
+    });
+
+    // The in-memory save path refuses non-objects so `caddy_revert apply` can't
+    // replay garbage into /load; hydration has to hold the same line.
+    it.each([
+      ["a bare string", '"just a string"'],
+      ["an array", "[1,2,3]"],
+      ["null", "null"],
+      ["a number", "42"],
+    ])("refuses to hydrate %s that merely parses as JSON", async (_label, contents) => {
+      const { writeFileSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      writeFileSync(join(tmp as string, "snapshot-1700000000000-manual.json"), contents, "utf-8");
+
+      vi.resetModules();
+      const snapshots = await import("../snapshots.js");
+      expect(snapshots.listSnapshots()).toHaveLength(0);
+    });
+
+    it("keeps valid snapshots alongside a non-object one", async () => {
+      const { writeFileSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      writeFileSync(join(tmp as string, "snapshot-1700000000001-manual.json"), '"bad"', "utf-8");
+      writeFileSync(join(tmp as string, "snapshot-1700000000002-manual.json"), '{"apps":{}}', "utf-8");
+
+      vi.resetModules();
+      const snapshots = await import("../snapshots.js");
+      const snaps = snapshots.listSnapshots();
+      expect(snaps).toHaveLength(1);
+      expect(snaps[0]?.config).toEqual({ apps: {} });
+    });
+
+    it("survives a corrupt snapshot file instead of losing the whole ring", async () => {
+      const { writeFileSync, mkdirSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const snapshots = await import("../snapshots.js");
+      snapshots.clearSnapshots();
+      snapshots.saveSnapshot({ good: true }, "manual");
+
+      mkdirSync(tmp as string, { recursive: true });
+      writeFileSync(join(tmp as string, "snapshot-99-corrupt.json"), "{not json", "utf-8");
+
+      vi.resetModules();
+      const restarted = await import("../snapshots.js");
+      const snaps = restarted.listSnapshots();
+      expect(snaps).toHaveLength(1);
+      expect(snaps[0]?.config).toEqual({ good: true });
+    });
+
+    it("falls back to memory-only when the directory cannot be written", async () => {
+      // A path whose parent is a FILE, so mkdirSync fails. The save must still
+      // land in the in-memory ring.
+      const { writeFileSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const blocker = join(tmp as string, "blocker");
+      writeFileSync(blocker, "x", "utf-8");
+      process.env.CADDY_MCP_SNAPSHOT_DIR = join(blocker, "nested");
+
+      vi.resetModules();
+      const snapshots = await import("../snapshots.js");
+      snapshots.clearSnapshots();
+      expect(() => snapshots.saveSnapshot({ a: 1 }, "manual")).not.toThrow();
+      expect(snapshots.listSnapshots()).toHaveLength(1);
     });
   });
 

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -252,6 +252,89 @@ describe.skipIf(!RUN)("integration: live Caddy admin API", () => {
     expect(routes.data?.[1]?.handle?.[0]?.status_code).toBe(201);
   });
 
+  // Pins the Caddy write semantics caddy_tls's fallback depends on. The unit
+  // tests for that fallback mock the api module, so they cannot see that Caddy
+  // rejects one of these verbs -- which is exactly how a PUT that could never
+  // succeed survived in the fallback path.
+  //
+  // PUT on a NON-array key is strictly-create: 409 "key already exists".
+  // PATCH on the same key replaces it. If a future Caddy relaxes PUT, this test
+  // fails and the fallback could be simplified; if PATCH ever starts requiring
+  // something else, it fails the other way.
+  it("PUT on an existing object key conflicts; PATCH replaces it", async () => {
+    const loadRes = await api.loadConfig({
+      apps: {
+        tls: { automation: { policies: [{ issuers: [{ module: "acme", email: "a@b.test" }] }] } },
+        http: { servers: { srv0: { listen: [":18893"] } } },
+      },
+    });
+    assertOk(loadRes, "loadConfig with apps/tls");
+
+    const merged = {
+      automation: { policies: [{ issuers: [{ module: "acme", email: "a@b.test", profile: "shortlived" }] }] },
+    };
+
+    const putRes = await api.configPut("apps/tls", merged);
+    expect(putRes.ok).toBe(false);
+    expect(putRes.status).toBe(409);
+    expect(putRes.error).toContain("already exists");
+
+    const patchRes = await api.configPatch("apps/tls", merged);
+    assertOk(patchRes, "configPatch apps/tls");
+
+    const issuer = await api.configGet<{ profile?: unknown }>("apps/tls/automation/policies/0/issuers/0");
+    assertOk(issuer, "configGet issuer");
+    expect(issuer.data?.profile).toBe("shortlived");
+  });
+
+  // The other half of the same story: the sub-path PATCH that caddy_tls tries
+  // FIRST fails on a key the issuer does not carry yet, which is why
+  // set_acme_profile reaches the fallback on the normal path rather than as an
+  // edge case.
+  it("PATCH of an absent issuer sub-key 404s, sending set_acme_profile down the fallback", async () => {
+    const loadRes = await api.loadConfig({
+      apps: {
+        tls: { automation: { policies: [{ issuers: [{ module: "acme", email: "a@b.test" }] }] } },
+        http: { servers: { srv0: { listen: [":18894"] } } },
+      },
+    });
+    assertOk(loadRes, "loadConfig with apps/tls");
+
+    const res = await api.configPatch("apps/tls/automation/policies/0/issuers/0/profile", "shortlived");
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(404);
+    expect(res.error).toContain("key does not exist");
+  });
+
+  // A config write's body is a JSON value, so a string must be JSON-encoded.
+  // Sending it bare makes Caddy answer 500 "decoding request body: invalid
+  // character ...". Mocked tests cannot see this, which is how every
+  // string-valued write shipped broken.
+  it("writes a string value as JSON rather than a bare body", async () => {
+    const loadRes = await api.loadConfig({
+      apps: {
+        tls: { automation: { policies: [{ issuers: [{ module: "acme", email: "a@b.test" }] }] } },
+        http: { servers: { srv0: { listen: [":18895"] } } },
+      },
+    });
+    assertOk(loadRes, "loadConfig with apps/tls");
+
+    const res = await api.configPatch("apps/tls/automation/policies/0/issuers/0/email", "changed@b.test");
+    assertOk(res, "configPatch string value");
+
+    const issuer = await api.configGet<{ email?: unknown }>("apps/tls/automation/policies/0/issuers/0");
+    assertOk(issuer, "configGet issuer");
+    expect(issuer.data?.email).toBe("changed@b.test");
+  });
+
+  // The opposite side of that switch: /adapt takes a raw document, so a string
+  // body must NOT be JSON-encoded on the way out.
+  it("still sends a Caddyfile to /adapt as a raw document", async () => {
+    const res = await api.adapt<{ result?: unknown }>(':18896 {\n  respond "ok"\n}\n');
+    assertOk(res, "adapt Caddyfile");
+    expect(res.data?.result).toBeDefined();
+  });
+
   it("configByIdGet + Delete works end-to-end", async () => {
     const loadRes = await api.loadConfig({
       apps: {

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -550,7 +550,7 @@ describe("caddy-mcp tools", () => {
       expect(result.content[0].text).toContain("caddy_config_set");
     });
 
-    it("PUTs merged config when GET returns expected shape, preserving siblings", async () => {
+    it("PATCHes merged config when GET returns expected shape, preserving siblings", async () => {
       const handler = await getTlsHandler();
       const existing = {
         automation: {
@@ -559,23 +559,30 @@ describe("caddy-mcp tools", () => {
         },
       };
       const captured: { method?: string; body?: any } = {};
-      globalThis.fetch = vi.fn(async (_url: any, opts: any) => {
-        if (opts?.method === "PATCH") {
-          return new Response("patch-failed", { status: 500 });
-        }
+      // Dispatch on URL, not method, the way a real Caddy does: a PATCH of the
+      // issuer sub-path 404s when that key is absent, while a PATCH of the whole
+      // apps/tls object succeeds. Keying on method alone would fail the merge
+      // too, now that both writes are PATCHes.
+      globalThis.fetch = vi.fn(async (url: any, opts: any) => {
+        const path = new URL(url.toString()).pathname;
+        const isWholeTls = path === "/config/apps/tls";
         if (opts?.method === "GET") {
           return new Response(JSON.stringify(existing), { status: 200 });
         }
-        if (opts?.method === "PUT") {
-          captured.method = "PUT";
+        if (opts?.method === "PATCH" && !isWholeTls) {
+          return new Response("key does not exist", { status: 404 });
+        }
+        if (opts?.method === "PATCH" && isWholeTls) {
+          captured.method = "PATCH";
           captured.body = JSON.parse(opts.body);
           return new Response("", { status: 200 });
         }
-        return new Response("nope", { status: 500 });
+        // A PUT here would be the 409 bug -- fail loudly if one is ever sent.
+        return new Response(`unexpected ${opts?.method} ${path}`, { status: 500 });
       }) as any;
       const result = await handler({ action: "set_acme_ca", ca: "https://new.ca/dir" });
       expect(result.isError).toBeFalsy();
-      expect(captured.method).toBe("PUT");
+      expect(captured.method).toBe("PATCH");
       expect(captured.body.automation.on_demand).toEqual({ rate_limit: { interval: "10s" } });
       expect(captured.body.automation.policies[0].issuers[0]).toEqual({
         module: "acme",

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -2,16 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import * as api from "../api.js";
 import { formatResult } from "../format.js";
-import { getSnapshot, listSnapshots, saveSnapshot } from "../snapshots.js";
-
-/**
- * A snapshot must be re-applyable via /load, which requires a JSON object root.
- * Strings, arrays, null, and primitives are not valid Caddy configs -- refuse
- * to capture them so a later `caddy_revert apply` can't replay garbage.
- */
-function isSnapshotableConfig(data: unknown): data is Record<string, unknown> {
-  return data !== null && typeof data === "object" && !Array.isArray(data);
-}
+import { getSnapshot, isSnapshotableConfig, listSnapshots, saveSnapshot } from "../snapshots.js";
 
 export function registerConfigTools(server: McpServer) {
   server.tool(
@@ -126,7 +117,10 @@ export function registerConfigTools(server: McpServer) {
 
   server.tool(
     "caddy_revert",
-    "Manage config snapshots for rollback. Snapshots are auto-captured before caddy_load and kept in-memory (last 10). Actions: 'list' shows snapshots with timestamps, 'save' manually captures the current config, 'apply' restores a snapshot (requires confirm=true).",
+    "Manage config snapshots for rollback. Snapshots are auto-captured before caddy_load (last 10). " +
+      "By default they live in memory only and are LOST when this server restarts -- set CADDY_MCP_SNAPSHOT_DIR " +
+      "to a writable directory to persist them across restarts (they contain full Caddy configs, so pick the location deliberately). " +
+      "Actions: 'list' shows snapshots with timestamps, 'save' manually captures the current config, 'apply' restores a snapshot (requires confirm=true).",
     {
       action: z.enum(["list", "save", "apply"]).describe("Action to perform"),
       index: z

--- a/src/tools/tls.ts
+++ b/src/tools/tls.ts
@@ -4,11 +4,28 @@ import type { ApiResponse } from "../api.js";
 import * as api from "../api.js";
 import { formatResult } from "../format.js";
 
+/**
+ * The ACME issuer fields this tool can set. Each maps 1:1 onto a field of
+ * Caddy's `acme` issuer module: `email`, `ca`, and `profile`.
+ *
+ * `profile` arrived in Caddy 2.10 (ACME profiles, an experimental draft). It
+ * selects certificate properties the CA offers by name -- Let's Encrypt uses
+ * it to issue 6-day short-lived certs under the "shortlived" profile. Caddy
+ * passes the value through untouched, so the set of valid names is the CA's to
+ * define, not ours to validate.
+ */
+interface IssuerFields {
+  email?: string;
+  ca?: string;
+  profile?: string;
+}
+
 /** Build a minimal TLS automation config with ACME issuer fields (used only when apps/tls is absent) */
-function buildTlsConfig(fields: { email?: string; ca?: string }) {
+function buildTlsConfig(fields: IssuerFields) {
   const issuer: Record<string, string> = { module: "acme" };
   if (fields.email) issuer.email = fields.email;
   if (fields.ca) issuer.ca = fields.ca;
+  if (fields.profile) issuer.profile = fields.profile;
   return {
     automation: {
       policies: [{ issuers: [issuer] }],
@@ -44,13 +61,14 @@ function deepClone<T>(v: T): T {
  * Apply email/ca patch to a deep copy of an existing apps/tls config that already
  * contains automation.policies[0].issuers[0]. Caller must have validated the shape.
  */
-function mergeIssuerFields(existing: Record<string, unknown>, fields: { email?: string; ca?: string }) {
+function mergeIssuerFields(existing: Record<string, unknown>, fields: IssuerFields) {
   const merged = deepClone(existing);
   // Cast through unknown — we've shape-checked the path before reaching here.
   const automation = merged.automation as { policies: Array<{ issuers: Array<Record<string, unknown>> }> };
   const issuer = automation.policies[0].issuers[0];
   if (fields.email !== undefined) issuer.email = fields.email;
   if (fields.ca !== undefined) issuer.ca = fields.ca;
+  if (fields.profile !== undefined) issuer.profile = fields.profile;
   return merged;
 }
 
@@ -98,11 +116,7 @@ type FallbackOutcome =
  *  - merge into existing config and PUT it back (preserves siblings), or
  *  - refuse with a shape-specific error (do not clobber).
  */
-async function safeFallback(
-  label: string,
-  patchRes: ApiResponse,
-  fields: { email?: string; ca?: string },
-): Promise<FallbackOutcome> {
+async function safeFallback(label: string, patchRes: ApiResponse, fields: IssuerFields): Promise<FallbackOutcome> {
   const getRes = await api.configGet<unknown>("apps/tls");
 
   // Branch 1: apps/tls absent (404 or empty/null body) -> POST is safe.
@@ -169,44 +183,89 @@ async function safeFallback(
   return { kind: "tool-error", result: bothErrors(label, patchRes, putRes, "PUT") };
 }
 
+/**
+ * Set one ACME issuer field: PATCH the exact sub-path first (which works
+ * whenever the issuer already exists), then fall back to the shape-checked
+ * create-or-merge path when it does not.
+ *
+ * Shared by set_email / set_acme_ca / set_acme_profile so all three keep
+ * identical clobber-safety semantics -- the fallback is the delicate part, and
+ * three hand-copied versions of it would drift.
+ */
+async function setIssuerField(field: keyof IssuerFields, value: string, label: string) {
+  const patchRes = await api.configPatch(`apps/tls/automation/policies/0/issuers/0/${field}`, value);
+  const ok = { content: [{ type: "text" as const, text: `${label} set to: ${value}` }] };
+  if (patchRes.ok) return ok;
+  const outcome = await safeFallback(label, patchRes, { [field]: value });
+  return outcome.kind === "ok" ? ok : outcome.result;
+}
+
+function missingArgError(text: string) {
+  return { isError: true as const, content: [{ type: "text" as const, text: `Error: ${text}` }] };
+}
+
 export function registerTlsTools(server: McpServer) {
   server.tool(
     "caddy_tls",
-    "Get or configure TLS/HTTPS settings. Actions: 'status' shows current TLS config, 'set_email' sets the ACME email, 'set_acme_ca' sets the ACME CA URL. Works on both fresh and existing Caddy instances.",
+    "Get or configure TLS/HTTPS settings. Actions: 'status' shows current TLS config, 'set_email' sets the ACME email, " +
+      "'set_acme_ca' sets the ACME CA URL, 'set_acme_profile' sets the ACME profile (Caddy 2.10+), " +
+      "'ech_status' reads the Encrypted ClientHello config (Caddy 2.10+, read-only here). " +
+      "Works on both fresh and existing Caddy instances. Writes target policies[0].issuers[0] only -- " +
+      "on a multi-policy TLS config, edit the intended policy with caddy_config_set instead.",
     {
-      action: z.enum(["status", "set_email", "set_acme_ca"]).describe("Action to perform"),
+      action: z
+        .enum(["status", "set_email", "set_acme_ca", "set_acme_profile", "ech_status"])
+        .describe("Action to perform"),
       email: z.string().optional().describe("ACME email address (for 'set_email' action)"),
       ca: z.string().optional().describe("ACME CA URL (for 'set_acme_ca' action)"),
+      profile: z
+        .string()
+        .optional()
+        .describe(
+          "ACME profile name (for 'set_acme_profile'). Requires Caddy 2.10+ and a CA that offers profiles; " +
+            "Let's Encrypt uses 'shortlived' for 6-day certificates. Valid names are defined by the CA, not by Caddy.",
+        ),
     },
     { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
-    async ({ action, email, ca }) => {
+    async ({ action, email, ca, profile }) => {
       if (action === "status") {
         return formatResult(await api.configGet("apps/tls"));
       }
-      if (action === "set_email") {
-        if (!email)
+      if (action === "ech_status") {
+        // Encrypted ClientHello lives at apps/tls/ech (Caddy 2.10+). Read-only:
+        // enabling ECH needs a DNS provider credential and a publication policy,
+        // which belong in a full config written via caddy_load, not a one-field
+        // PATCH.
+        const echRes = await api.configGet("apps/tls/ech");
+        // ECH is rarely enabled, so "not configured" is the ordinary answer
+        // rather than a failure. Caddy reports a missing config path as a 404
+        // (or an empty body); surfacing that as `Error: not found` would answer
+        // the common case with a error the caller has to interpret.
+        const absent =
+          (!echRes.ok && echRes.status === 404) || (echRes.ok && (echRes.data === undefined || echRes.data === null));
+        if (absent) {
           return {
-            isError: true,
-            content: [{ type: "text" as const, text: "Error: email is required for set_email action" }],
+            content: [
+              {
+                type: "text" as const,
+                text: "ECH (Encrypted ClientHello) is not configured on this instance. Requires Caddy 2.10+; enable it by applying a config with apps/tls/ech via caddy_load.",
+              },
+            ],
           };
-        // Try PATCH first (works when the path already exists)
-        const patchRes = await api.configPatch("apps/tls/automation/policies/0/issuers/0/email", email);
-        if (patchRes.ok) return { content: [{ type: "text" as const, text: `ACME email set to: ${email}` }] };
-        const outcome = await safeFallback("ACME email", patchRes, { email });
-        if (outcome.kind === "ok") return { content: [{ type: "text" as const, text: `ACME email set to: ${email}` }] };
-        return outcome.result;
+        }
+        return formatResult(echRes);
+      }
+      if (action === "set_email") {
+        if (!email) return missingArgError("email is required for set_email action");
+        return setIssuerField("email", email, "ACME email");
       }
       if (action === "set_acme_ca") {
-        if (!ca)
-          return {
-            isError: true,
-            content: [{ type: "text" as const, text: "Error: ca is required for set_acme_ca action" }],
-          };
-        const patchRes = await api.configPatch("apps/tls/automation/policies/0/issuers/0/ca", ca);
-        if (patchRes.ok) return { content: [{ type: "text" as const, text: `ACME CA set to: ${ca}` }] };
-        const outcome = await safeFallback("ACME CA", patchRes, { ca });
-        if (outcome.kind === "ok") return { content: [{ type: "text" as const, text: `ACME CA set to: ${ca}` }] };
-        return outcome.result;
+        if (!ca) return missingArgError("ca is required for set_acme_ca action");
+        return setIssuerField("ca", ca, "ACME CA");
+      }
+      if (action === "set_acme_profile") {
+        if (!profile) return missingArgError("profile is required for set_acme_profile action");
+        return setIssuerField("profile", profile, "ACME profile");
       }
       return { isError: true, content: [{ type: "text" as const, text: `Unknown action: ${action}` }] };
     },

--- a/src/tools/tls.ts
+++ b/src/tools/tls.ts
@@ -175,12 +175,22 @@ async function safeFallback(label: string, patchRes: ApiResponse, fields: Issuer
     };
   }
 
-  // Branch 2: shape is good — merge into a deep copy and PUT it back so siblings (custom certs,
-  // on_demand, certificate_authorities, additional policies/issuers) are preserved.
+  // Branch 2: shape is good — merge into a deep copy and write it back whole so siblings
+  // (custom certs, on_demand, certificate_authorities, additional policies/issuers) are
+  // preserved. Sibling preservation comes from merging the full object, not from the verb.
+  //
+  // PATCH, not PUT. Caddy's PUT on a non-array key is strictly-create: it returns
+  //   409 {"error":"[/config/apps/tls] key already exists: tls"}
+  // whenever apps/tls is already present -- which is exactly the condition this branch
+  // runs under, so the PUT could never succeed. PATCH requires the key to exist, which it
+  // does here. Verified against Caddy 2.11.4: PUT -> 409, PATCH -> 200 with the issuer
+  // replaced. This mattered little for set_email/set_acme_ca (a configured issuer already
+  // carries those keys, so the PATCH happy path handles them), but a fresh ACME issuer
+  // never carries `profile`, so set_acme_profile reaches this branch on the normal path.
   const merged = mergeIssuerFields(getRes.data, fields);
-  const putRes = await api.configPut("apps/tls", merged);
-  if (putRes.ok) return { kind: "ok" };
-  return { kind: "tool-error", result: bothErrors(label, patchRes, putRes, "PUT") };
+  const mergeRes = await api.configPatch("apps/tls", merged);
+  if (mergeRes.ok) return { kind: "ok" };
+  return { kind: "tool-error", result: bothErrors(label, patchRes, mergeRes, "PATCH apps/tls") };
 }
 
 /**


### PR DESCRIPTION
Tracks the Caddy 2.10/2.11 admin-API surface and closes gaps found in a full pass over the server.

Caddy's documented endpoint set is unchanged and this server already covered all of it (`/load`, `/stop`, `/config/*`, `/id/*`, `/adapt`, `/reverse_proxy/upstreams`, `/pki/ca/*`, `/metrics`). What was missing were config surfaces and one transport.

## Changes

**Unix-socket admin endpoints.** `CADDY_ADMIN_URL` now accepts `unix:///var/run/caddy-admin.sock` and Caddy's own `unix//var/run/caddy-admin.sock` spelling, routed through `node:http` because the global `fetch` cannot dial a unix socket at all. Moving the admin API onto a socket is Caddy's own hardening recommendation, so those instances were previously unreachable.

The unix path deliberately sends **no** `Origin` header -- the inverse of the TCP path. Caddy builds no default origin allowlist for a unix/fd listener and only runs its origin check when `Origin` or `Sec-Fetch-Mode` is present, so sending one opts into a check against an empty list and always 403s. Verified against `admin.go` at v2.11.4 (`enforceHost = !isWildcardInterface && !IsUnixNetwork && !IsFdNetwork`).

**ACME profiles + ECH status.** `set_acme_profile` sets the issuer's `profile` field (Caddy 2.10; Let's Encrypt uses `shortlived` for 6-day certs). `ech_status` reads `apps/tls/ech` read-only -- enabling ECH needs a DNS provider credential and a publication policy, which belong in a full config via `caddy_load`.

**Snapshot persistence.** Opt-in `CADDY_MCP_SNAPSHOT_DIR` persists the `caddy_revert` ring across restarts. Opt-in because snapshots are full configs and can carry secrets.

**Release gate.** `release.sh` now runs the 9 live-Caddy integration tests against a *scratch* Caddy on its own admin port. Those tests are the only thing pinning the admin-API contracts this server rests on, and `npm test` skips all of them unless `CADDY_MCP_INTEGRATION=1` -- so a Caddy release that changed any of them would previously have shipped silently.

## Testing

333 passing (+20), 11 skipped. Lint and `tsc --noEmit` clean.

Two caveats worth a reviewer's attention:
- The two unix-socket tests are POSIX-gated and **did not run** on the Windows workstation this was developed on. The unix transport is the least-exercised code in the diff.
- The `release.sh` gate is syntax-checked only -- there is no `caddy` binary on that workstation, so the scratch-instance path has not actually executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)