### PR TITLE
docs: correct the 2.3.0 release date to 2026-08-23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.3.0] — 2026-08-22
+## [2.3.0] — 2026-08-23
 
 ### Added
 


### PR DESCRIPTION
One-character fix. The 2.3.0 entry was written on the 22nd, but the release was cut on the 23rd -- npm, the GitHub release, and the MCP Registry all record 2026-08-23.

`CHANGELOG.md` is not in package.json's `files` list, so the published tarball is unaffected and no republish is needed.

Going through a PR rather than a direct push so the default-branch ruleset is satisfied without an admin bypass.