### PR TITLE
fix(launcher): actually enforce the oam minimum version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The minimum oam version is now actually enforced.** `oamVersion()` and `atLeast()` were defined but never called, so `OAM_MIN` was dead code and any oam on the box was spawned regardless of version — including the pre-0.9.0 releases the floor exists to exclude, where `child_process.execFile` ran its arguments through a shell, `exec` accepted `timeout` and ignored it, and `stdio: 'inherit'` behaved as `'pipe'`. This launcher shells out on its main paths, so those were reachable bugs. An oam below the floor is now refused under `CADDY_MCP_RUNTIME=oam` and bypassed for Node under `auto`, in both cases saying which version it found.
+
 ### Fixed
 - **The launcher no longer dies with a raw stack trace when `spawn` fails.** Node throws synchronously rather than emitting `error` for some unexecutable targets — notably a `.cmd`/`.bat` on Windows — and the `error` listener is registered *after* the `spawn` call, so it could never observe that throw. Both failure modes now route through one handler.
 - **Windows `PATH` discovery accepts `oam.exe` only**, instead of walking every `PATHEXT` entry and returning an `oam.cmd` Node cannot execute. A skipped shim is still **named** in the diagnostic, so an npm-style install no longer reports as "no oam binary was found".

--- a/bin/caddy-mcp.mjs
+++ b/bin/caddy-mcp.mjs
@@ -250,6 +250,14 @@ if (mode === "node") {
   await runInProcess();
 } else {
   const oam = findOam();
+  // Read the version ONCE, and only when discovery found something: the gate
+  // below has to tell "too old" apart from "could not be read at all", and
+  // re-probing inside the branch would cost a second subprocess.
+  //
+  // This is the first subprocess the launcher runs -- discovery itself is
+  // stat-only. Paid on every launch that finds an oam, including the ones
+  // that go on to fall back to Node.
+  const found = oam ? oamVersion(oam) : null;
 
   if (!oam) {
     // An oam-named .cmd/.bat on PATH is a real install in a shape this
@@ -276,6 +284,29 @@ if (mode === "node") {
     // auto: falling back is correct, but silence is how someone never learns
     // their oam install is a shape this launcher skips.
     if (oamShim) await errSync(`caddy-mcp: ${shimNote}Using Node instead.\n`);
+    await runInProcess();
+  } else if (!atLeast(found, OAM_MIN)) {
+    const min = OAM_MIN.join(".");
+    // Two different causes reach this branch and they need different
+    // remedies. `found === null` is NOT "old": oamVersion returns null when
+    // the binary could not be run at all (not executable, wrong arch, a
+    // .cmd/.bat Node refuses, deleted between the stat and the probe) or
+    // when its --version output did not parse. Telling that user to
+    // `oam self-update` sends them after the one cause it definitely is not.
+    const detail = found
+      ? `${oam} is oam ${found.join(".")}, older than ${min}`
+      : `${oam} could not be run, or did not report a version this launcher understands`;
+    const remedy = found
+      ? "Run `oam self-update`, or use CADDY_MCP_RUNTIME=node.\n"
+      : "Check that it is an executable oam binary for this platform, or use CADDY_MCP_RUNTIME=node.\n";
+    if (mode === "oam") {
+      await errSync(`caddy-mcp: CADDY_MCP_RUNTIME=oam but ${detail}.\n${remedy}`);
+      process.exit(1);
+    }
+    // auto: neither cause is worth failing over -- prefer Node. Say so,
+    // because a silent downgrade is how someone keeps running an oam they
+    // meant to update, or never learns their oam is unexecutable.
+    await errSync(`caddy-mcp: ${detail}; using Node instead.\n`);
     await runInProcess();
   } else {
     // `--` separates oam's own flags from the script's argv, so `caddy-mcp


### PR DESCRIPTION
`oamVersion()` and `atLeast()` were defined in this launcher but **never called**, so `OAM_MIN` was dead code and any oam on the box got spawned regardless of version. Every sibling launcher has this gate; these two were the outliers.

## Why the floor exists

Below oam 0.9.0, `child_process.execFile` ran its arguments through a **shell**, `exec` accepted `timeout` and ignored it, `spawnSync` truncated at `maxBuffer` while reporting success, and `stdio: 'inherit'`/`'ignore'` both behaved as `'pipe'`. This launcher shells out to a CLI on its main paths, so those were reachable bugs — an argument containing shell metacharacters was re-split and executed.

## What changed

The gate matches the sibling launchers, including the unreadable-vs-outdated split: `oamVersion()` returns `null` for several distinct causes (not executable, wrong architecture, a shim Node refuses, deleted since the stat, unparseable `--version`), and reporting those as "older than" would send the user to `oam self-update` — the single remedy that cannot apply.

**This is a behaviour change, not a port.** An oam below the floor that used to be spawned is now refused under `<NAME>_RUNTIME=oam` and bypassed for Node under `auto`. That is the intent — silently running a runtime with known `child_process` bugs is the worse outcome — but it is why these two were held back from the mechanical fixes and raised separately.

## Verification

Against the real launcher, with the floor temporarily raised so a genuine executable reads as old:

```
old oam, auto  -> falls back to Node, "... is oam 22.22.2, older than 99.0.0"
old oam, oam   -> exit 1
unexecutable   -> "could not be run, or did not report a version" (NOT "older than")
good oam       -> still spawned, not bypassed   <- non-regression check
```

`node --check` passes. Note `npm run lint` scopes to `src/`, so `bin/` is not linted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)