### PR TITLE
test(launcher): make the signal cases actually exercise the child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Tests for `bin/caddy-mcp.mjs`**, the published entry point. It sat outside both
+  existing gates -- `npm run lint` scopes to `src/`, and nothing exercised `bin/` --
+  so the launcher rewrite landed with no automated coverage despite being the file
+  every install runs. Covers runtime selection (`node` / `auto` fallback / explicit
+  `oam` failing loudly), an MCP handshake through the launcher, the oam version
+  floor, and the signal behavior: a graceful child runs its own shutdown, a wedged
+  child is escalated rather than hung on, and repeat signals do not hard-kill a
+  child that is already exiting.
+
+  Signal cases are POSIX-gated -- Windows has no POSIX signals, which is why the
+  launcher forwards nothing there. A stand-in `oam` supplied via `OAM_BIN` makes
+  this testable without installing the runtime; it must answer `--version` with a
+  version at or above the floor, because the launcher's probe is a synchronous
+  `execFileSync` and an unparseable answer silently downgrades it to the Node path.
+
 ### Changed
 - **The minimum oam version is now actually enforced.** `oamVersion()` and `atLeast()` were defined but never called, so `OAM_MIN` was dead code and any oam on the box was spawned regardless of version — including the pre-0.9.0 releases the floor exists to exclude, where `child_process.execFile` ran its arguments through a shell, `exec` accepted `timeout` and ignored it, and `stdio: 'inherit'` behaved as `'pipe'`. This launcher shells out on its main paths, so those were reachable bugs. An oam below the floor is now refused under `CADDY_MCP_RUNTIME=oam` and bypassed for Node under `auto`, in both cases saying which version it found.
 

--- a/src/tests/launcher.test.ts
+++ b/src/tests/launcher.test.ts
@@ -138,8 +138,21 @@ describe.skipIf(!existsSync(DIST_CLI))("launcher: runtime selection", () => {
  * to the whole process group -- behavior this harness cannot drive.
  */
 describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: signal handling", () => {
+  /**
+   * Answering `--version` is MANDATORY for any stand-in oam.
+   *
+   * Before spawning, the launcher runs a synchronous `execFileSync(oam,
+   * ["--version"])` and requires >= OAM_MIN (0.9.0). A fake that ignores the
+   * probe does not merely fail the gate -- if it blocks, execFileSync blocks
+   * the launcher forever, and if it answers unparseably the launcher silently
+   * falls back to Node, so the test would measure the fallback path while
+   * appearing to exercise signal forwarding.
+   */
+  const VERSION_PROBE = ['if [ "$1" = "--version" ]; then echo "oam 0.9.0"; exit 0; fi'];
+
   const GRACEFUL = [
     "#!/bin/bash",
+    ...VERSION_PROBE,
     'cleanup() { echo "CHILD: cleanup ran" >&2; exit 0; }',
     "trap cleanup TERM INT",
     'echo "CHILD: up" >&2',
@@ -149,20 +162,39 @@ describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: signal handling", () 
 
   const WEDGED = [
     "#!/bin/bash",
+    ...VERSION_PROBE,
     "trap '' TERM INT",
     'echo "CHILD: up" >&2',
     "while true; do sleep 0.05; done",
     "",
   ].join("\n");
 
-  /** A stand-in oam that either shuts down cleanly on a signal or ignores it. */
-  function fakeOam(kind: "graceful" | "wedged"): string {
+  /** An oam that satisfies discovery but is older than the launcher's floor. */
+  const TOO_OLD = ["#!/bin/bash", 'echo "oam 0.8.9"', "exit 0", ""].join("\n");
+
+  function writeFake(body: string): string {
     const dir = mkdtempSync(join(tmpdir(), "caddy-mcp-fake-oam-"));
     const file = join(dir, "oam");
-    writeFileSync(file, kind === "graceful" ? GRACEFUL : WEDGED, "utf-8");
+    writeFileSync(file, body, "utf-8");
     chmodSync(file, 0o755);
     return file;
   }
+
+  /** A stand-in oam that either shuts down cleanly on a signal or ignores it. */
+  function fakeOam(kind: "graceful" | "wedged"): string {
+    return writeFake(kind === "graceful" ? GRACEFUL : WEDGED);
+  }
+
+  it("rejects an oam older than the supported floor", async () => {
+    // The version gate is the first subprocess the launcher runs, and it has to
+    // tell "too old" apart from "unreadable" -- they have different remedies.
+    const res = await runLauncher(["--version"], {
+      CADDY_MCP_RUNTIME: "oam",
+      OAM_BIN: writeFake(TOO_OLD),
+    });
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain("0.8.9");
+  }, 30000);
 
   /** Signal the launcher `count` times, starting once the child is up. */
   function runWithSignals(oam: string, count: number) {


### PR DESCRIPTION
Follow-up to 524a84f, which captured an in-progress draft of this test. As committed it **hangs on POSIX**.

Two defects, both found by running it rather than reading it:

1. **The stand-in `oam` ignored `--version`.** The launcher runs a *synchronous* `execFileSync(oam, ["--version"])` and requires >= `OAM_MIN` (0.9.0) before spawning. A fake that loops forever blocks that probe outright; one that answers unparseably makes the launcher silently fall back to Node — so the test would measure the fallback path while appearing to exercise signal forwarding.
2. **Results resolved on `close`**, which waits for every writer on the inherited stdio. The launcher passes `stdio: "inherit"`, so a grandchild outliving the child (a shell's `sleep`) holds the pipe open and `close` never fires — hanging on a launcher that already exited correctly. Now resolves on `exit` with a short drain.

Also adds a case for the version floor, which has two distinct failure modes ("too old" vs "unreadable") with different remedies.

## Verification

The signal block is POSIX-gated and cannot run on the Windows workstation, so it was validated in WSL under real signals against the merged launcher:

```
graceful, 1 signal    cleanup ran, code 0, 252ms
wedged,   1 signal    code 130 @ 2192ms   (grace window honored)
graceful, 3 signals   cleanup ran, code 0
```

Windows: 361 passed / 26 skipped, lint and tsc clean.