### PR TITLE
chore: ignore Windows reserved device names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ dist-release/
 # npm auth token -- never commit (a project-local .npmrc can be
 # created by tooling and would carry a live automation token)
 .npmrc
+
+# Windows reserved device names. In Git Bash a redirect like `> NUL` or
+# `2>CONOUT$` creates a real FILE here instead of writing to the device, so
+# these turn up as untracked noise after routine tooling runs. Never
+# legitimate content. (Same class: CON, CONIN$, PRN, AUX, COM1-9, LPT1-9.)
+NUL
+CONOUT$


### PR DESCRIPTION
In Git Bash a redirect like `> NUL` or `2>CONOUT$` creates a real **file** in the working directory instead of writing to the device. Both turned up in the repo root during this session's release work.

They are never legitimate content, so ignoring them costs nothing — and it stops the noise from reaching a `git add` by accident, which matters in a shared checkout where an untracked file has already been swept into a commit once.

Verified with `git check-ignore -v`:

```
.gitignore:18:NUL       NUL
.gitignore:19:CONOUT$  CONOUT$
```

`$` has no special meaning in gitignore, so `CONOUT$` matches literally. The comment names the wider class (CON, CONIN$, PRN, AUX, COM1-9, LPT1-9) without ignoring names nobody has hit.

lint clean, tsc clean, 361 tests passing.