### PR TITLE
docs: document the worktree-per-session convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,3 +91,33 @@ npm run lint:fix   # Biome auto-fix
 npm run typecheck  # tsc --noEmit
 npm run test:ci    # Build + test
 ```
+
+## Parallel sessions: use a worktree per session
+
+Two agent sessions sharing this checkout collide in two ways that are easy to
+miss and expensive to unpick: one session's `git checkout` moves HEAD under the
+other mid-task, and an untracked work-in-progress file gets swept into the other
+session's `git add`. Both happened here on 2026-08-23.
+
+Give each session its own worktree instead:
+
+```bash
+git worktree add ../caddy-mcp-worktrees/session-c -b session-c main
+cd ../caddy-mcp-worktrees/session-c && npm ci
+git worktree list          # see them all
+git worktree remove ../caddy-mcp-worktrees/session-c
+```
+
+Each worktree has its own HEAD, branch, and working tree, backed by the one
+shared `.git`, so branches and commits are visible everywhere immediately.
+
+**Worktrees must live OUTSIDE this directory** -- `../caddy-mcp-worktrees/`, not
+`.claude/worktrees/`. `vitest.config.ts` sets no `include`, so vitest uses its
+default `**/*.{test,spec}.?(c|m)[jt]s?(x)` glob: a worktree nested anywhere under
+the repo root makes `npm test` in the MAIN checkout discover every worktree's
+copy of the suite. Being in `.gitignore` does not help -- vitest does not consult
+it (`vcs.useIgnoreFile` is unset in `biome.json` too).
+
+Each worktree needs its own `npm ci` (~170 MB). Do not share one `node_modules`
+via a symlink or junction: that reintroduces exactly the shared mutable state the
+worktrees exist to remove.


### PR DESCRIPTION
Two sessions sharing this checkout collided twice today: one moved HEAD under the other mid-review, and an untracked work-in-progress test file was swept into the other session's commit (524a84f) and pushed to main in a state that **hangs on POSIX**.

A worktree per session removes both failure modes — separate HEAD, branch, and working tree over one shared `.git`.

Records the two constraints that are not obvious and cost real time to find:

**Worktrees must live outside the repo root.** `vitest.config.ts` sets no `include`, so vitest uses its default `**/*.{test,spec}.?(c|m)[jt]s?(x)` glob — a worktree nested anywhere under the repo makes `npm test` in the *main* checkout discover every worktree's copy of the suite. Being in `.gitignore` does not help; vitest does not consult it (`vcs.useIgnoreFile` is unset in `biome.json` too).

**Each worktree needs its own `npm ci`** (~170 MB). Sharing one `node_modules` via a symlink/junction reintroduces exactly the shared mutable state the worktrees exist to remove.

Two worktrees are already set up locally (`session-a`, `session-b`), verified: each runs the full gate independently (lint, tsc, build, 361 tests), and a branch switch + commit + untracked file in one is invisible to the other and to main.

lint clean, tsc clean, 361 tests passing.