### PR TITLE
Revert "docs: document the worktree-per-session convention"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,33 +91,3 @@ npm run lint:fix   # Biome auto-fix
 npm run typecheck  # tsc --noEmit
 npm run test:ci    # Build + test
 ```
-
-## Parallel sessions: use a worktree per session
-
-Two agent sessions sharing this checkout collide in two ways that are easy to
-miss and expensive to unpick: one session's `git checkout` moves HEAD under the
-other mid-task, and an untracked work-in-progress file gets swept into the other
-session's `git add`. Both happened here on 2026-08-23.
-
-Give each session its own worktree instead:
-
-```bash
-git worktree add ../caddy-mcp-worktrees/session-c -b session-c main
-cd ../caddy-mcp-worktrees/session-c && npm ci
-git worktree list          # see them all
-git worktree remove ../caddy-mcp-worktrees/session-c
-```
-
-Each worktree has its own HEAD, branch, and working tree, backed by the one
-shared `.git`, so branches and commits are visible everywhere immediately.
-
-**Worktrees must live OUTSIDE this directory** -- `../caddy-mcp-worktrees/`, not
-`.claude/worktrees/`. `vitest.config.ts` sets no `include`, so vitest uses its
-default `**/*.{test,spec}.?(c|m)[jt]s?(x)` glob: a worktree nested anywhere under
-the repo root makes `npm test` in the MAIN checkout discover every worktree's
-copy of the suite. Being in `.gitignore` does not help -- vitest does not consult
-it (`vcs.useIgnoreFile` is unset in `biome.json` too).
-
-Each worktree needs its own `npm ci` (~170 MB). Do not share one `node_modules`
-via a symlink or junction: that reintroduces exactly the shared mutable state the
-worktrees exist to remove.


### PR DESCRIPTION
Reverts 77fd109 (#37).

The section was written on a wrong premise. I attributed a run of surprises in this repo — HEAD moving mid-task, an untracked work-in-progress file swept into a commit (524a84f), worktrees disappearing — to a second agent session working the same checkout. There was no second session: `ListAgents` shows nine peers and none is caddy-mcp. It was the repo owner working directly, which is not a collision hazard and needs no mitigation.

The observations were real; "parallel agent sessions" was the wrong explanation, so guidance built on it does not belong in CLAUDE.md.

The local worktrees (`session-a`, `session-b`, `session-c`) are removed, along with their branches, git admin records, and the container directory.

**The two constraints are worth keeping here rather than in the repo**, in case worktrees are ever wanted:

1. They must live **outside** the repo root. `vitest.config.ts` sets no `include`, so vitest uses its default `**/*.{test,spec}` glob — a worktree nested anywhere under the repo makes `npm test` in the *main* checkout discover every worktree copy of the suite. `.gitignore` does not help; vitest does not consult it.
2. Each worktree needs its own `npm ci` (~170 MB). Sharing one `node_modules` via a junction reintroduces the shared mutable state worktrees exist to remove.

lint clean, tsc clean, 361 tests passing.