### PR TITLE
feat(launcher): raise the shutdown grace window to 5s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The launcher's shutdown grace window is 5 seconds, up from 2.** The timer only
+  ever elapses when the child has NOT exited on its own, and what follows is a hard
+  kill (`SIGKILL`, or `TerminateProcess` on Windows) of a server that may be
+  mid-shutdown -- flushing a large config, finishing a TLS provision. Waiting too
+  long costs a few extra seconds on an already-wedged child; waiting too little
+  truncates a legitimate shutdown, which is the failure this timer exists to avoid
+  causing. A graceful child is unaffected: it still exits on its own in
+  milliseconds, well inside either window.
+
 ## [2.3.1] — 2026-08-23
 
 ### Added

--- a/bin/caddy-mcp.mjs
+++ b/bin/caddy-mcp.mjs
@@ -397,7 +397,12 @@ if (mode === "node") {
       // graceful shutdown the console's own Ctrl-C just started, skipping the
       // child's process.on("exit") cleanup. The console has already notified the
       // child, so on Windows the timer below is the only kill we issue.
-      const ESCALATE_AFTER_MS = 2000;
+      // 5s, not 2s. This is a HARD kill of a server that may be mid-shutdown --
+      // flushing a large config, finishing a TLS provision -- and the cost of
+      // waiting too long (a wedged child lingers a few extra seconds) is far
+      // smaller than the cost of cutting a legitimate shutdown short. The window
+      // only ever elapses when the child has NOT exited on its own.
+      const ESCALATE_AFTER_MS = 5000;
       let escalation = null;
       for (const sig of ["SIGINT", "SIGTERM"]) {
         process.on(sig, () => {

--- a/src/tests/launcher.test.ts
+++ b/src/tests/launcher.test.ts
@@ -212,8 +212,9 @@ describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: signal handling", () 
     const res = await runWithSignals(fakeOam("graceful"), 1);
     expect(res.stderr).toContain("CHILD: cleanup ran");
     expect(res.code).toBe(0);
-    // Well inside the 2s escalation window -- the child's own exit ended this.
-    expect(res.ms).toBeLessThan(6000);
+    // Must stay well BELOW ESCALATE_AFTER_MS (5s): that is what proves the
+    // child's own exit ended this rather than the escalation timer firing.
+    expect(res.ms).toBeLessThan(3000);
   }, 30000);
 
   it("escalates on a wedged child instead of hanging forever", async () => {
@@ -223,8 +224,8 @@ describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: signal handling", () 
     // hatch -- verified against the pre-fix launcher, which hung indefinitely.
     const res = await runWithSignals(fakeOam("wedged"), 1);
     expect(res.code).toBe(130); // 128 + SIGINT
-    expect(res.ms).toBeGreaterThan(1200); // the grace window was actually honored
-    expect(res.ms).toBeLessThan(8000);
+    expect(res.ms).toBeGreaterThan(4000); // the full 5s grace window was honored
+    expect(res.ms).toBeLessThan(12000);
   }, 30000);
 
   it("does not hard-kill a graceful child when signals repeat", async () => {


### PR DESCRIPTION
The escalation timer only ever elapses when the child has **not** exited on its own — and what follows is a hard kill (`SIGKILL`, or `TerminateProcess` on Windows) of a server that may be mid-shutdown: flushing a large config, finishing a TLS provision.

The costs are asymmetric. Waiting too long means an already-wedged child lingers a few extra seconds. Waiting too little truncates a legitimate shutdown — precisely the failure this timer exists to avoid causing.

## Test bound tightened too

The graceful-case assertion moves from `<6000ms` to `<3000ms`. At a 2s window `<6000` was loose but valid; at 5s it would no longer distinguish *"the child exited on its own"* from *"the escalation timer fired"* — the test would keep passing while silently proving nothing.

## Verification

The signal block is POSIX-gated and cannot run on the Windows workstation, so it was validated in WSL under real signals against the patched launcher:

```
graceful, 1 signal    cleanup ran, code 0, 977ms    (unaffected)
wedged,   1 signal    code 130 @ 5617ms             (was 2192ms at the 2s window)
graceful, 3 signals   cleanup ran, code 0
```

The `[2.3.1]` changelog entry still describes the 2s window it shipped with; the new value is recorded under `[Unreleased]`.

Windows: 361 passed / 26 skipped, lint + tsc + build clean.