### PR TITLE
docs: promote [Unreleased] to 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2] — 2026-08-23
+
 ### Changed
 - **The launcher's shutdown grace window is 5 seconds, up from 2.** The timer only
   ever elapses when the child has NOT exited on its own, and what follows is a hard


### PR DESCRIPTION
Promoted before cutting the tag. `release.sh` does not do this step, and v2.3.1 shipped with its entire changelog still under `[Unreleased]` as a result.

Contents: the launcher's shutdown grace window moves from 2s to 5s. No API change to any tool.