### PR TITLE
fix: harden config-path handling, first-run UX, and destructive-tool guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Config paths are percent-encoded per segment.** A `#` or `?` in a config key
+  truncated the request URL, because both are URL syntax rather than path text:
+  `caddy_config_delete { path: "apps/http/servers/prod#1" }` sent
+  `/config/apps/http/servers/prod` and deleted the PARENT server, reporting HTTP
+  200 success. Reproduced against Caddy 2.11.4 and fixed by encoding each segment
+  (so `/` keeps its separator meaning) — the raw path deleted `prod`, the encoded
+  path deletes exactly `prod#1`. Traversal rejection still runs on the decoded
+  form, so a literal `..` is still refused and a supplied `%2e%2e` is escaped
+  rather than decoded into one.
+- **`caddy_list_routes` reported an unknown server as an empty one.** Caddy answers
+  a server name it does not know with HTTP 200 and a body of literal `null`, not a
+  404, so the failure guard never fired and the null collapsed into an empty
+  config: a mistyped name rendered as `no routes configured` with no error flag,
+  telling an operator a live-looking server was empty and inviting them to
+  overwrite it. It now errors, naming both possible causes — an absent key and a
+  key whose value is `null` are byte-identical on the wire, and both are reachable.
+- **`caddy_remove_route` could delete a non-route object by `@id`.** `@id`s are
+  config-global in Caddy, so a removal targeting an id shared by a TLS issuer or a
+  server block deleted that object instead. It now reads the object first and
+  refuses anything without a top-level `handle` array, matching the guard
+  `caddy_reverse_proxy` already applied on the write path.
+- **`https://` upstreams are no longer silently downgraded to plaintext.** The
+  scheme was stripped, so `to: ["https://backend"]` dialed port 80 in the clear.
+- **`caddy_tls` refuses to write ACME fields onto a non-ACME issuer.** A config
+  whose first issuer is `internal` (Caddy's local CA — an ordinary setup) accepted
+  `email`/`profile` keys it has no use for, and `set_acme_ca` would silently
+  repoint that issuer's own `ca` field at an ACME directory URL.
+- **`CADDY_MCP_SANDBOX=1` denied every request.** Three separate faults: the
+  launcher's default endpoint did not match the one `src/api.ts` dials; the grant
+  pinned a port, which the `fetch` permission check never matches; and
+  `CADDY_MCP_SNAPSHOT_DIR` was absent from the environment allowlist, so snapshot
+  persistence degraded to memory-only with no diagnostic. A unix-socket admin URL
+  additionally produced a BARE `--allow-net`, granting the whole network for the
+  most hardened admin configuration Caddy recommends; it now emits no net grant at
+  all, which is what denies the category.
+- **An empty `tls_connection_policies` array no longer reports `TLS: enabled`.** It
+  configures nothing, so it now reads the same as an absent key.
+- **Resource reads no longer render `Error: undefined`** when a failure carries no
+  error text; they fall back to the status code the way tool results already did.
+
+### Changed
+- **`caddy_revert apply` says so when no roll-forward snapshot was captured.** If
+  the pre-revert read fails — which happens for an ordinary reason, since Caddy
+  restarts its admin listener on every `/load` — the revert still succeeds, but the
+  config it replaced went unrecorded and the revert cannot itself be undone. That
+  now appears in the result instead of a bare success message.
+- **Corrected two MCP tool hints.** `caddy_config_by_id` declares
+  `destructiveHint: true` (it has a `delete` action), and `caddy_remove_route`
+  declares `idempotentHint: false` (true for `@id`, false for index removal, where
+  Caddy re-packs the array so a repeated index removes a different route).
+- **`caddy_reverse_proxy` rejects an empty `to` array and blank upstream entries**
+  rather than writing a proxy with no upstreams or a `dial` of `""`.
+
+### Added
+- **Roughly 60 tests**, covering the fixes above plus the branches a coverage pass
+  found unpinned: the `caddy_list_routes` formatter arms (a null matcher, a
+  `dial`-less upstream, `file_server`, and the `rewrite`/`authentication`/`error`
+  placeholders — each of which threw or misreported on an ordinary Caddy config),
+  the launcher's version-gate and spawn-failure fallbacks, and the empty-body error
+  branch in `src/api.ts`. Four run against a live Caddy, where the mocked suite
+  cannot see what the admin API actually returns.
+- **`esbuild` is declared in `devDependencies`.** `scripts/build-binary.mjs`
+  imports it directly but it resolved only as a transitive install.
+
 ## [2.3.2] — 2026-08-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The first-run path works.** On an instance with no config, Caddy has no `apps`
+  key, so config reads fail the path walk instead of returning empty:
+  `caddy_list_servers` answered a fresh instance with
+  `{"error":"invalid traversal path at: config/apps/http"}` — a Go internal error
+  from the tool whose entire job is to say what exists. It now reports `No HTTP
+  servers configured`, matching `caddy_status` on the same state, and
+  `caddy_list_routes` returns the create-it recipe. A traversal failure is
+  decisive — no parent chain means no server — so asserting non-existence is honest
+  here, unlike the ambiguous null body, which keeps its both-causes wording.
+- **The "server does not exist" advice now works if you follow it.** It said to
+  create the server with `{ "listen": [":443"] }`, which omits two things the
+  follower needs: `mode: "append"`, because the default `overwrite` is a PATCH that
+  fails with `key does not exist`; and `"routes": []`, because a POST creates a
+  missing `routes` key as an *object*, so the very next call died with
+  `cannot unmarshal object into ... RouteList`. A live test now follows the advice
+  verbatim and adds a route to what it produces.
+- **`serverNotFoundError` was unreachable from all three of its call sites.**
+  `isParentMissing` matched only `404` / `key does not exist`, but a POST under a
+  missing server answers HTTP 500 `invalid traversal path` — a shape no mocked
+  fixture had ever produced — so the raw Go error reached the caller instead of the
+  recipe. Both markers are matched now.
+- **`caddy_config_delete` no longer advertises itself as idempotent.** Its own
+  documented example path ends in an array index, and Caddy re-packs the array
+  after a delete, so a repeat removes a different route. `caddy_remove_route`
+  already carried this correction for the byte-identical underlying request.
 - **Config paths are percent-encoded per segment.** A `#` or `?` in a config key
   truncated the request URL, because both are URL syntax rather than path text:
   `caddy_config_delete { path: "apps/http/servers/prod#1" }` sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Roughly 60 tests**, covering the fixes above plus the branches a coverage pass
   found unpinned: the `caddy_list_routes` formatter arms (a null matcher, a
   `dial`-less upstream, `file_server`, and the `rewrite`/`authentication`/`error`
-  placeholders — each of which threw or misreported on an ordinary Caddy config),
-  the launcher's version-gate and spawn-failure fallbacks, and the empty-body error
-  branch in `src/api.ts`. Four run against a live Caddy, where the mocked suite
-  cannot see what the admin API actually returns.
+  placeholders — all of which already handled these shapes correctly, but had no
+  test saying so, and each sits one careless edit away from throwing on a config
+  Caddy accepts), the launcher's version-gate and spawn-failure fallbacks, and the
+  empty-body error branch in `src/api.ts`. Four run against a live Caddy, where the
+  mocked suite cannot see what the admin API actually returns.
 - **`esbuild` is declared in `devDependencies`.** `scripts/build-binary.mjs`
   imports it directly but it resolved only as a transitive install.
 

--- a/bin/caddy-mcp.mjs
+++ b/bin/caddy-mcp.mjs
@@ -32,11 +32,25 @@
  * `CADDY_MCP_SANDBOX=1` runs the server under oam's permission model.
  *
  * The admin API endpoint is DERIVED from CADDY_ADMIN_URL (default
- * http://127.0.0.1:2019), host and port both pinned -- grants are prefix-matched,
- * so a bare host would also admit every other port on it. Filesystem AND
- * child-process both stay denied: this server drives Caddy entirely over its
- * admin HTTP API and never shells out to the `caddy` binary (the only
- * execFileSync calls in the repo are in src/tests/).
+ * http://localhost:2019 -- byte-identical to DEFAULT_URL in src/api.ts, see
+ * sandboxFlags). For a TCP endpoint the grant is the HOST, deliberately WITHOUT
+ * a port: oam checks `fetch` against the bare hostname and sockets against
+ * "host:port", and grants are prefix-matched, so pinning the port denies every
+ * fetch -- and fetch is the transport api.ts uses for everything but a unix
+ * socket. Granting the host therefore also admits its other ports; that is the
+ * cost of the check having no port to match against.
+ *
+ * A unix-socket CADDY_ADMIN_URL gets NO net grant, which DENIES the category
+ * outright -- it is not an oversight that it looks narrower than the TCP case.
+ * oam ships no unix socket transport, so the socket dial cannot work under the
+ * sandbox regardless; the alternative was a bare `--allow-net`, which grants
+ * every host on the network. See sandboxFlags for the mechanism.
+ *
+ * Child-process stays denied: this server drives Caddy entirely over its admin
+ * HTTP API and never shells out to the `caddy` binary (the only execFileSync
+ * calls in the repo are in src/tests/). Filesystem stays denied too, EXCEPT when
+ * CADDY_MCP_SNAPSHOT_DIR is set: snapshot persistence is the one feature that
+ * touches disk, so that directory -- and nothing else -- is granted read+write.
  *
  * Opt-in, not default: a denied environment variable is ABSENT from process.env
  * rather than throwing, so an under-granted CADDY_API_TOKEN reads as
@@ -111,6 +125,14 @@ function findOam() {
   // the full PATHEXT list would hand back a path this launcher cannot execute.
   // Discovery has to agree with execution. A skipped shim is still reported --
   // see findOamShim.
+  //
+  // scripts/runtime.mjs carries its OWN findOam that DOES walk the full PATHEXT.
+  // That is a deliberate difference, not drift: it probes each candidate with
+  // execFileSync before returning it, so a shim it cannot run is dropped anyway
+  // and a wider walk only ever finds more. This one is stat-only on the hot
+  // launch path -- no probe to filter with -- so whatever it returns it must be
+  // able to spawn. Same question, different constraint; change one and re-read
+  // the other.
   for (const dir of (process.env.PATH ?? "").split(delimiter)) {
     if (!dir) continue;
     const candidate = join(dir, exe);
@@ -164,25 +186,118 @@ function sandboxFlags() {
   if (process.env.CADDY_MCP_SANDBOX !== "1") return [];
 
   // Derived, not hardcoded: the only endpoint this server may reach is the one
-  // it was configured to reach. Grants are prefix-matched against "host:port"
-  // for sockets, so host alone would also admit any other port on that host --
-  // pin both. A DSN we cannot parse falls back to a bare grant rather than a
-  // broken one, because a wrong narrow grant fails at connect time.
-  const dsn = process.env.CADDY_ADMIN_URL ?? "http://127.0.0.1:2019";
-  let netFlag = "--allow-net";
-  if (dsn) {
+  // it was configured to reach. A DSN we cannot parse falls back to a bare grant
+  // rather than a broken one, because a wrong narrow grant fails at connect time.
+  //
+  // The default MUST stay byte-identical to DEFAULT_URL in src/api.ts. The grant
+  // and the dial are matched as TEXT, so "127.0.0.1" here against an api.ts that
+  // dials "localhost" denies every request while both files look right on their
+  // own. Change one, change the other.
+  //
+  // Empty and whitespace-only are treated as UNSET, which is what api.ts does:
+  // it reads the variable with `||`, so "" already falls through to DEFAULT_URL
+  // there. `??` would keep "" here, skip the parse, and leave the bare
+  // `--allow-net` below -- a wide-open sandbox produced by a shell exporting an
+  // empty variable, which is a shape shells produce easily.
+  const dsn = process.env.CADDY_ADMIN_URL?.trim() || "http://localhost:2019";
+
+  // A unix-socket admin endpoint gets NO net grant at all -- checked before the
+  // URL parse, because it is the one input that would otherwise produce the
+  // WIDEST grant instead of the narrowest.
+  //
+  // `new URL("unix:///run/caddy.sock").hostname` is "", so the `if (u.hostname)`
+  // below is false and netFlag would stay the bare `--allow-net`; Caddy's own
+  // spelling (`unix//run/caddy.sock`) throws ERR_INVALID_URL and reaches the
+  // catch for the same result. Either way the most hardened admin config --
+  // Caddy recommends the socket precisely because filesystem permissions beat a
+  // loopback port -- would switch the sandbox on and hand over the whole network.
+  // That is the same wide-open-by-accident shape the empty-string case above
+  // guards against, reached by a different route.
+  //
+  // Omitting the flag DENIES the category (oam reads an absent --allow-net as
+  // false, a bare one as "*"), and denial costs nothing here: oam has no unix
+  // socket transport at all, so api.ts's node:http `socketPath` dial cannot work
+  // under oam whether the grant is open or closed. Verified against oam 0.9.0 --
+  // bare grant lets an unrelated host through, omitted grant denies it.
+  //
+  // This mirrors getMalformedUnixUrl's predicate in src/api.ts, NOT the stricter
+  // getUnixSocketPath -- deliberately, and the difference is the whole point.
+  //
+  // getUnixSocketPath accepts only the two WELL-FORMED spellings; matching it
+  // here would leave the malformed ones ("unix:/one-slash", "unix://relative",
+  // "unix://", or any uppercase spelling, which getUnixSocketPath rejects for
+  // case) falling through to the parse, where they yield an empty hostname and
+  // the bare `--allow-net` -- fully open, for input that plainly meant a socket.
+  //
+  // Denying the category for those costs nothing: api.ts routes exactly this set
+  // to getMalformedUnixUrl, which fails the request up front with a message
+  // naming the spelling error, so no request is ever attempted. Matching the
+  // broad predicate is what makes the header's claim true for EVERY unix-ish
+  // input rather than just the two tidy ones.
+  //
+  // `[:/]` after "unix" rather than a bare "unix" prefix, so a real TCP host like
+  // "http://unix.example.com:2019" is not swept up -- the same care api.ts takes.
+  const isUnixDsn = /^unix[:/]/i.test(dsn);
+
+  let netFlag = isUnixDsn ? null : "--allow-net";
+  if (!isUnixDsn) {
     try {
       const u = new URL(dsn);
-      if (u.hostname) netFlag = `--allow-net=${u.hostname}:${u.port || 2019}`;
+      // HOST ONLY, no port, deliberately. Grants are prefix-matched against the
+      // resource string, and the resource `fetch` presents is the bare hostname
+      // ("localhost") while sockets present "host:port". "localhost" does not
+      // start with "localhost:2019", so pinning the port denies every fetch --
+      // and fetch is how api.ts talks to a TCP admin endpoint. Granting the host
+      // alone also admits the other ports on that host; that is the cost of the
+      // check having no port to match against, not an oversight here.
+      if (u.hostname) netFlag = `--allow-net=${u.hostname}`;
     } catch {
-      // Unparseable CADDY_ADMIN_URL: leave the grant open. The server will fail on
-      // its own connection error, which names the real problem.
+      // Genuinely unparseable CADDY_ADMIN_URL (not the unix forms -- those are
+      // handled above): leave the grant open. The server will fail on its own
+      // connection error, which names the real problem.
     }
   }
 
-  const env = ["CADDY_ADMIN_URL", "CADDY_API_TOKEN", "CADDY_LOAD_TIMEOUT", "CADDY_MAX_RETRIES", "CADDY_TIMEOUT"];
+  // Every variable the shipped bundle reads (`grep process.env src/`), including
+  // CADDY_MCP_SNAPSHOT_DIR in src/snapshots.ts. Omitting one is not a denial the
+  // operator can see: the variable is simply ABSENT, so the feature reads as
+  // "not configured" and degrades silently.
+  const env = [
+    "CADDY_ADMIN_URL",
+    "CADDY_API_TOKEN",
+    "CADDY_LOAD_TIMEOUT",
+    "CADDY_MAX_RETRIES",
+    "CADDY_MCP_SNAPSHOT_DIR",
+    "CADDY_TIMEOUT",
+  ];
 
-  const flags = ["--permission", netFlag, `--allow-env=${env.join(",")}`];
+  // netFlag is null for a unix DSN -- an OMITTED --allow-net is what denies the
+  // category, so it must not survive as a stray "null" argv entry.
+  const flags = ["--permission", netFlag, `--allow-env=${env.join(",")}`].filter(Boolean);
+
+  // The filesystem grant exists only when snapshot persistence is switched on,
+  // and only for the directory it points at. Granting the variable without the
+  // directory would just move the silent failure: src/snapshots.ts swallows its
+  // own I/O errors and degrades to the in-memory ring, so `caddy_revert` would
+  // quietly stop surviving a restart -- the thing the operator turned the
+  // variable on to get.
+  //
+  // TWO spellings, because grants are matched as plain string PREFIXES against
+  // whatever path each call passes: snapshots.ts hands the raw variable to
+  // readdirSync/mkdirSync but builds per-file paths with path.join, which
+  // normalizes ("./snaps" -> "snaps"). The raw form alone then misses the files;
+  // the normalized form alone misses the directory listing.
+  //
+  // Two consequences worth naming rather than discovering: a prefix also admits
+  // a sibling path that merely starts with the same string ("/var/snap" grants
+  // "/var/snapshots-elsewhere"), and oam splits the list on commas with no
+  // escape, so a directory whose path contains a comma cannot be granted here.
+  const snapshotDir = process.env.CADDY_MCP_SNAPSHOT_DIR?.trim();
+  if (snapshotDir) {
+    const forms = [...new Set([snapshotDir, join(snapshotDir, ".")])].join(",");
+    flags.push(`--allow-fs-read=${forms}`, `--allow-fs-write=${forms}`);
+  }
+
   return flags;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,12 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "caddy-mcp": "dist/index.js"
+        "caddy-mcp": "bin/caddy-mcp.mjs"
       },
       "devDependencies": {
         "@biomejs/biome": "~2.4.11",
         "@types/node": "^26.0.0",
+        "esbuild": "^0.28.1",
         "postject": "^1.0.0-alpha.6",
         "tsup": "^8.4.0",
         "typescript": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@biomejs/biome": "~2.4.11",
     "@types/node": "^26.0.0",
+    "esbuild": "^0.28.1",
     "postject": "^1.0.0-alpha.6",
     "tsup": "^8.4.0",
     "typescript": "^7.0.2",

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Build a self-contained single-file binary of the @yawlabs/mcp sidecar.
+// Build a self-contained single-file binary of the @yawlabs/caddy-mcp server.
 //
 // Strategy: esbuild bundles src/index.ts + ALL its dependencies (including
 // the externals tsup leaves out -- @modelcontextprotocol/sdk and undici)
@@ -13,8 +13,12 @@
 // Deno-compatible in principle (clean ESM, no native addons), but the node:
 // builtin imports in the bundle are bare (`fs`, not `node:fs`), which Deno
 // rejects without a compat shim. Node SEA needs no such rewrite and ships with
-// the Node already on the box, so it is the zero-friction path here. See
-// BINARY_DISTRIBUTION.md for the deno/bun fallbacks.
+// the Node already on the box, so it is the zero-friction path here.
+//
+// The deno paragraph above is the whole of what this repo records about
+// alternative carriers. An earlier revision of this comment referred the reader
+// to a BINARY_DISTRIBUTION.md for the deno/bun fallbacks; no such file exists
+// in this repo, or anywhere in its history.
 //
 // This script ONLY reads node_modules (via esbuild's resolver) and writes to
 // build-tmp/ and bin/<platform>-<arch>/. It does NOT mutate package.json,
@@ -236,6 +240,9 @@ console.log("");
 console.log(`OK  ${outExe}`);
 console.log(`    ${fmtSize(outExe)}`);
 console.log("");
+// `--version` is the ONLY safe probe to print here. src/index.ts special-cases
+// --version/-V and falls through to startServer() for every other argv, so any
+// invented subcommand (this line used to suggest `doctor --json`) does not
+// error -- it starts the stdio server and HANGS waiting on stdin.
 console.log("Verify with:");
 console.log(`    "${outExe}" --version`);
-console.log(`    "${outExe}" doctor --json`);

--- a/scripts/runtime.mjs
+++ b/scripts/runtime.mjs
@@ -62,7 +62,18 @@ function installedCandidates() {
   return paths;
 }
 
-/** Absolute paths for `oam` on PATH, so callers see WHERE it came from. */
+/**
+ * Absolute paths for `oam` on PATH, so callers see WHERE it came from.
+ *
+ * bin/caddy-mcp.mjs carries its OWN findOam, and the two are deliberately not
+ * shared: this one walks the full PATHEXT on Windows, the launcher's is
+ * restricted to `.exe`. Node cannot spawn a .cmd/.bat without `shell: true`,
+ * and the launcher's discovery is stat-only on the hot launch path, so whatever
+ * it returns it must be able to execute -- discovery there has to agree with
+ * execution. Here the candidate is probed with execFileSync before it is
+ * returned (see findOam below), so a shim that cannot be run is dropped anyway
+ * and a wider walk only ever finds more. Keep them separate.
+ */
 function pathCandidates() {
   const found = [];
   const exts = isWin ? (process.env.PATHEXT ?? ".EXE").split(";").filter(Boolean) : [""];

--- a/scripts/stage-release-asset.mjs
+++ b/scripts/stage-release-asset.mjs
@@ -1,11 +1,18 @@
 #!/usr/bin/env node
 // Stage the host-built SEA binary as a named release asset + sha256 sidecar.
 //
-// build-binary.mjs emits bin/<platform>-<arch>/yaw-mcp(.exe) (host-native --
-// Node SEA cannot cross-compile, so each CI matrix leg builds its own). This
-// renames that to the public asset name the Scoop/Homebrew manifests point at
-// (yaw-mcp-<platform>-<arch>[.exe]) and writes a `<asset>.sha256` sidecar in
-// sha256sum format (`<hex>  <asset>`) that Scoop's autoupdate `hash.url` reads.
+// build-binary.mjs emits bin/<platform>-<arch>/caddy-mcp(.exe) -- both scripts
+// derive that name from package.json's first `bin` key rather than hardcoding
+// it, which is what keeps them copy-paste generic across @yawlabs/* servers.
+// This renames it to the public asset name the Scoop/Homebrew manifests point
+// at (caddy-mcp-<platform>-<arch>[.exe]) and writes a `<asset>.sha256` sidecar
+// in sha256sum format (`<hex>  <asset>`) that Scoop's autoupdate `hash.url`
+// reads.
+//
+// The build is host-native (Node SEA cannot cross-compile), so every platform
+// you ship needs its own run of build-binary.mjs + this script. There is no CI
+// matrix doing that here -- this repo has no .github/workflows at all, so it is
+// a manual per-host step (see update-manifests.mjs for the full release chain).
 //
 // Pure stdlib; writes only to dist-release/. Run after build-binary.mjs:
 //   node scripts/stage-release-asset.mjs
@@ -44,7 +51,9 @@ writeFileSync(outSha, `${hex}  ${assetName}\n`);
 
 console.log(`asset:  ${outAsset}`);
 console.log(`sha256: ${hex}`);
-// Surfaced as a step output in CI (GITHUB_OUTPUT) for downstream jobs.
+// A no-op in this repo, which has no workflows: kept because this script is
+// copy-pasted into @yawlabs/* siblings that DO run it under Actions, where a
+// downstream job reads the asset name and hash as step outputs.
 if (process.env.GITHUB_OUTPUT) {
   writeFileSync(process.env.GITHUB_OUTPUT, `asset=${assetName}\nsha256=${hex}\n`, { flag: "a" });
 }

--- a/scripts/update-manifests.mjs
+++ b/scripts/update-manifests.mjs
@@ -7,8 +7,14 @@
 // slug, license, description), so this script is copy-paste across @yawlabs/*
 // servers -- only the sibling-repo dirs are flags. Mirrors the Yaw Terminal
 // release.sh pattern: the manifest repos are checked out next to this one and
-// pushed with the gh_woods SSH key -- no CI cross-repo token. The binary BUILD
-// is CI (release.yml on tag push); this manifest BUMP runs locally after.
+// pushed with the gh_woods SSH key -- no CI cross-repo token.
+//
+// Nothing in this repo's release chain runs in CI -- there is no
+// .github/workflows directory at all, only CODEOWNERS. The whole flow is local
+// and ordered: release.sh cuts the tag, publishes to npm and creates the GitHub
+// release; each platform then runs build-binary.mjs + stage-release-asset.mjs
+// by hand and uploads its asset + `.sha256` sidecar to that release; this
+// manifest BUMP runs last, because step 1 below downloads those sidecars.
 //
 //   node scripts/update-manifests.mjs --version 0.60.6 \
 //     [--scoop-dir ~/yaw/scoop-yaw] [--homebrew-dir ~/yaw/homebrew-yaw] [--push]

--- a/src/api.ts
+++ b/src/api.ts
@@ -239,6 +239,29 @@ function isTransientFailure(res: ApiResponse): boolean {
   return false;
 }
 
+/**
+ * Caddy's "a segment of this config path does not exist" failure.
+ *
+ * Caddy walks a config path one segment at a time and reports the first segment it
+ * cannot enter as `invalid traversal path at: <path>`. The STATUS varies with the
+ * verb -- 400 on a GET, 500 on a POST, both observed on 2.11.4 -- so the body is
+ * the only signal that holds across call sites.
+ *
+ * DISTINCT from `404 key does not exist`, which Caddy emits when the object exists
+ * but the named sub-key does not (a PATCH of an absent issuer field, say). Both
+ * mean "what you named is not there", so a caller translating a missing parent
+ * usually wants both markers; matching only the 404 form leaves the traversal case
+ * falling through as a raw Go error.
+ *
+ * Exported because two tools need it and they live in different modules: the route
+ * tools translate it into "that server does not exist", and caddy_list_servers
+ * reads it as "no HTTP servers are configured at all".
+ */
+export function isMissingConfigPath(res: Pick<ApiResponse, "ok" | "error">): boolean {
+  if (res.ok) return false;
+  return (res.error ?? "").toLowerCase().includes("invalid traversal path");
+}
+
 /** Matches a trailing array index, e.g. ".../routes/0" -- the shape Caddy PUT inserts at. */
 const ARRAY_INDEX_TAIL_RE = /\/\d+$/;
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -73,6 +73,30 @@ function invalidateRelated(path: string): void {
   }
 }
 
+/**
+ * The admin API base URL, trailing slashes stripped.
+ *
+ * A PATH PREFIX in CADDY_ADMIN_URL is preserved on purpose. An admin endpoint
+ * fronted by a reverse proxy commonly lives under one
+ * (`https://gw.example.com/caddy-admin`), and dropping it would send every
+ * request to the gateway's root. So the request URL is `<base><path>` --
+ * `configGet("apps")` under that base is `/caddy-admin/config/apps`.
+ *
+ * Two places deliberately do NOT see the prefix:
+ *   - the Origin header (getAdminOrigin), because an origin is scheme+host+port
+ *     by definition and that is what Caddy's allowlist compares against;
+ *   - the connect-failure message, which reports the origin so the operator
+ *     reads a host:port and no credentials leak from a query string.
+ * Everything keyed on the path -- the ETag cache, the retry policy -- runs on
+ * the prefix-free path built by the exported helpers, so a prefix cannot change
+ * either. Only URL composition in attemptRequest sees it.
+ *
+ * A query or fragment in CADDY_ADMIN_URL is operator error, not a supported
+ * form: "http://h:2019/p?token=x" composes to "...?token=x/config/", where the
+ * query swallows the path. Left as-is rather than stripped because there is no
+ * legitimate base URL that carries one, and the connect message already hides
+ * the secret; see the characterization test in api.test.ts.
+ */
 function getBaseUrl(): string {
   return (process.env.CADDY_ADMIN_URL || DEFAULT_URL).replace(/\/+$/, "");
 }
@@ -157,6 +181,38 @@ function getHeaders(contentType?: string, overUnixSocket = false): Record<string
 /** Normalize config path — strip leading /config/ or / if present */
 function normalizePath(path: string): string {
   return path.replace(/^\/?(config(\/|$))?/, "");
+}
+
+/**
+ * Percent-encode a path one SEGMENT at a time.
+ *
+ * Caddy config keys are arbitrary strings -- a server named "prod#1", a key
+ * holding a "?" -- but the result is interpolated straight into a request URL,
+ * where "#" opens a fragment and "?" opens a query. Unencoded,
+ * `configDelete("apps/http/servers/prod#1")` sends
+ * `DELETE /config/apps/http/servers/prod`: everything from the "#" never leaves
+ * the client, so it deletes the PARENT server and reports success. Encoding
+ * turns those into %23 / %3F, so the whole key reaches Caddy and a key that
+ * does not exist 404s instead of silently resolving to a different one.
+ *
+ * Per segment rather than whole-string because encodeURIComponent("/") is
+ * "%2F" -- encoding in one shot would destroy the separator and address a
+ * single top-level key whose name happens to contain slashes.
+ *
+ * Safe because Go decodes it back: net/http parses the request target and
+ * Caddy's admin handler routes on r.URL.Path, which holds the DECODED path, so
+ * %23 arrives at the config lookup as "#".
+ *
+ * ORDERING IS LOAD-BEARING: callers run rejectTraversal on the DECODED path
+ * BEFORE encoding. Encoding first would let a caller-supplied "%2e%2e" past the
+ * check and hand Caddy a real ".." segment; checking first means that input is
+ * escaped to "%252e%252e" and lands as a literal key name.
+ */
+function encodePathSegments(path: string): string {
+  return path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
 }
 
 /** Reject path-traversal segments so config-scoped tools can't reach sibling admin endpoints like /load or /stop. */
@@ -495,35 +551,35 @@ export function configGet<T = any>(path = ""): Promise<ApiResponse<T>> {
   const normalized = normalizePath(path);
   const bad = rejectTraversal(normalized);
   if (bad) return Promise.resolve(bad);
-  return caddyRequest("GET", `/config/${normalized}`);
+  return caddyRequest("GET", `/config/${encodePathSegments(normalized)}`);
 }
 
 export function configPost<T = any>(path: string, value: unknown): Promise<ApiResponse<T>> {
   const normalized = normalizePath(path);
   const bad = rejectTraversal(normalized);
   if (bad) return Promise.resolve(bad);
-  return caddyRequest("POST", `/config/${normalized}`, value);
+  return caddyRequest("POST", `/config/${encodePathSegments(normalized)}`, value);
 }
 
 export function configPut<T = any>(path: string, value: unknown): Promise<ApiResponse<T>> {
   const normalized = normalizePath(path);
   const bad = rejectTraversal(normalized);
   if (bad) return Promise.resolve(bad);
-  return caddyRequest("PUT", `/config/${normalized}`, value);
+  return caddyRequest("PUT", `/config/${encodePathSegments(normalized)}`, value);
 }
 
 export function configPatch<T = any>(path: string, value: unknown): Promise<ApiResponse<T>> {
   const normalized = normalizePath(path);
   const bad = rejectTraversal(normalized);
   if (bad) return Promise.resolve(bad);
-  return caddyRequest("PATCH", `/config/${normalized}`, value);
+  return caddyRequest("PATCH", `/config/${encodePathSegments(normalized)}`, value);
 }
 
 export function configDelete<T = any>(path: string): Promise<ApiResponse<T>> {
   const normalized = normalizePath(path);
   const bad = rejectTraversal(normalized);
   if (bad) return Promise.resolve(bad);
-  return caddyRequest("DELETE", `/config/${normalized}`);
+  return caddyRequest("DELETE", `/config/${encodePathSegments(normalized)}`);
 }
 
 function getRequestTimeout(): number {
@@ -571,13 +627,25 @@ export function getUpstreams(): Promise<ApiResponse> {
 export function getPki(ca = "local"): Promise<ApiResponse> {
   const bad = rejectTraversal(ca);
   if (bad) return Promise.resolve(bad);
-  return caddyRequest("GET", `/pki/ca/${ca}`);
+  return caddyRequest("GET", `/pki/ca/${encodePathSegments(ca)}`);
 }
 
 export function getPkiCertificates(ca = "local"): Promise<ApiResponse> {
   const bad = rejectTraversal(ca);
   if (bad) return Promise.resolve(bad);
-  return caddyRequest("GET", `/pki/ca/${ca}/certificates`);
+  return caddyRequest("GET", `/pki/ca/${encodePathSegments(ca)}/certificates`);
+}
+
+/**
+ * Compose `/id/<id>` or `/id/<id>/<subpath>`, both halves segment-encoded.
+ *
+ * Segment-encoded rather than encodeURIComponent'd whole so a "/" in either
+ * half keeps the separator meaning it has today -- this fix is about "#" and
+ * "?" truncating the URL, not about tightening what counts as one key.
+ */
+function idPath(id: string, subpath: string): string {
+  const encodedId = encodePathSegments(id);
+  return subpath ? `/id/${encodedId}/${encodePathSegments(subpath)}` : `/id/${encodedId}`;
 }
 
 export function configByIdGet<T = any>(id: string, subpath = ""): Promise<ApiResponse<T>> {
@@ -585,7 +653,7 @@ export function configByIdGet<T = any>(id: string, subpath = ""): Promise<ApiRes
   if (badId) return Promise.resolve(badId);
   const bad = rejectTraversal(subpath);
   if (bad) return Promise.resolve(bad);
-  const path = subpath ? `/id/${id}/${subpath}` : `/id/${id}`;
+  const path = idPath(id, subpath);
   return caddyRequest("GET", path);
 }
 
@@ -599,7 +667,7 @@ export function configByIdSet<T = any>(
   if (badId) return Promise.resolve(badId);
   const bad = rejectTraversal(subpath);
   if (bad) return Promise.resolve(bad);
-  const path = subpath ? `/id/${id}/${subpath}` : `/id/${id}`;
+  const path = idPath(id, subpath);
   return caddyRequest(method, path, value);
 }
 
@@ -608,7 +676,7 @@ export function configByIdDelete<T = any>(id: string, subpath = ""): Promise<Api
   if (badId) return Promise.resolve(badId);
   const bad = rejectTraversal(subpath);
   if (bad) return Promise.resolve(bad);
-  const path = subpath ? `/id/${id}/${subpath}` : `/id/${id}`;
+  const path = idPath(id, subpath);
   return caddyRequest("DELETE", path);
 }
 

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,6 +1,18 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ApiResponse } from "./api.js";
 import * as api from "./api.js";
 import { applyMetricsControls, METRICS_DEFAULT_MAX_LINES } from "./tools/operational.js";
+
+/**
+ * Error body for a failed resource read. Mirrors the tool-side fallback in
+ * format.ts: `error` is optional on ApiResponse, and only the failure paths
+ * api.ts builds itself are guaranteed to fill it -- so interpolating it bare
+ * renders the literal string "Error: undefined" to the client. Falling back to
+ * the status code at least tells the caller what the server said.
+ */
+function errorText(res: ApiResponse): string {
+  return `Error: ${res.error || `HTTP ${res.status}`}`;
+}
 
 export function registerResources(server: McpServer) {
   server.resource("caddy-config", "caddy://config", { description: "Current Caddy JSON configuration" }, async () => {
@@ -10,7 +22,7 @@ export function registerResources(server: McpServer) {
         {
           uri: "caddy://config",
           mimeType: res.ok ? "application/json" : "text/plain",
-          text: res.ok ? JSON.stringify(res.data ?? {}, null, 2) : `Error: ${res.error}`,
+          text: res.ok ? JSON.stringify(res.data ?? {}, null, 2) : errorText(res),
         },
       ],
     };
@@ -27,7 +39,7 @@ export function registerResources(server: McpServer) {
           {
             uri: "caddy://upstreams",
             mimeType: res.ok ? "application/json" : "text/plain",
-            text: res.ok ? JSON.stringify(res.data ?? {}, null, 2) : `Error: ${res.error}`,
+            text: res.ok ? JSON.stringify(res.data ?? {}, null, 2) : errorText(res),
           },
         ],
       };
@@ -49,7 +61,7 @@ export function registerResources(server: McpServer) {
             {
               uri: "caddy://metrics",
               mimeType: "text/plain",
-              text: `Error: ${res.error}`,
+              text: errorText(res),
             },
           ],
         };
@@ -78,7 +90,7 @@ export function registerResources(server: McpServer) {
           {
             uri: "caddy://servers",
             mimeType: res.ok ? "application/json" : "text/plain",
-            text: res.ok ? JSON.stringify(res.data ?? {}, null, 2) : `Error: ${res.error}`,
+            text: res.ok ? JSON.stringify(res.data ?? {}, null, 2) : errorText(res),
           },
         ],
       };

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -116,6 +116,35 @@ describe("api", () => {
     expect(res.error).toContain("CADDY_API_TOKEN");
   });
 
+  // ORDERING IS THE POINT: the empty-body check runs BEFORE the 403 origin-allowlist branch below, so a
+  // bodiless 403 -- what an auth proxy fronting the admin API returns -- is diagnosed as a token problem
+  // and never reaches the Origin explanation. A 403 that DOES name an origin still gets it (see the "403
+  // origin rejection" block). Swapping the two branches, or widening the hint, sends the operator after
+  // the wrong cause with nothing going red.
+  it("hints at CADDY_API_TOKEN on an empty-body 403 and does not reach the Origin explanation", async () => {
+    const api = await import("../api.js");
+    globalThis.fetch = vi.fn(async () => new Response("", { status: 403 })) as any;
+
+    const res = await api.configGet();
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(403);
+    expect(res.error).toBe("HTTP 403 -- check CADDY_API_TOKEN");
+    expect(res.error).not.toContain("Origin");
+    expect(res.error).not.toContain("admin.origins");
+  });
+
+  it("gives a bare HTTP 404 on an empty body, with no token hint", async () => {
+    // Only 401/403 earn the hint. A bodiless 404 means the config path is absent, not that auth failed --
+    // pointing that operator at CADDY_API_TOKEN would be a wrong-cause chase.
+    const api = await import("../api.js");
+    globalThis.fetch = vi.fn(async () => new Response("", { status: 404 })) as any;
+
+    const res = await api.configGet("apps/http/servers/nope");
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(404);
+    expect(res.error).toBe("HTTP 404");
+  });
+
   it("does not add the token hint when the error body is non-empty", async () => {
     const api = await import("../api.js");
     globalThis.fetch = vi.fn(async () => new Response("forbidden by policy", { status: 403 })) as any;
@@ -1233,6 +1262,96 @@ describe("api", () => {
     });
   });
 
+  // A path prefix in CADDY_ADMIN_URL is PRESERVED on the wire -- intended, so
+  // an admin endpoint behind a path-prefixed reverse proxy is reachable. The
+  // only thing pinned before was the connect-error message (tools.test.ts),
+  // which strips to the origin; the request URL itself was unpinned, so the
+  // prefix could have been dropped without a single test going red.
+  describe("path-prefixed CADDY_ADMIN_URL", () => {
+    async function captureUrl(call: (a: typeof import("../api.js")) => Promise<unknown>) {
+      const api = await import("../api.js");
+      let raw = "";
+      globalThis.fetch = vi.fn(async (url: any) => {
+        raw = String(url);
+        return new Response("{}", { status: 200 });
+      }) as any;
+      await call(api);
+      return raw;
+    }
+
+    it("prepends the prefix to the request path", async () => {
+      process.env.CADDY_ADMIN_URL = "http://caddy.local:2019/caddy-admin";
+      const raw = await captureUrl((a) => a.configGet("apps"));
+      expect(raw).toBe("http://caddy.local:2019/caddy-admin/config/apps");
+    });
+
+    it("strips a trailing slash from the prefix rather than doubling it", async () => {
+      process.env.CADDY_ADMIN_URL = "http://caddy.local:2019/caddy-admin/";
+      const raw = await captureUrl((a) => a.configGet("apps"));
+      expect(raw).toBe("http://caddy.local:2019/caddy-admin/config/apps");
+    });
+
+    it("sends the bare origin as Origin, without the prefix", async () => {
+      // Caddy's admin allowlist compares scheme+host+port; an Origin carrying a
+      // path is not an origin and would never match.
+      process.env.CADDY_ADMIN_URL = "http://caddy.local:2019/caddy-admin";
+      const api = await import("../api.js");
+      let headers: any = {};
+      globalThis.fetch = vi.fn(async (_url: any, opts: any) => {
+        headers = opts.headers;
+        return new Response("{}", { status: 200 });
+      }) as any;
+
+      await api.configGet("apps");
+      expect(headers.Origin).toBe("http://caddy.local:2019");
+    });
+
+    it("keys the retry policy on the prefix-free path", async () => {
+      // POST /config/<path> is non-idempotent and must not retry. The policy
+      // reads the path the exported helpers build, which never carries the
+      // prefix -- if the prefix ever leaked into it, the startsWith("/config/")
+      // check would miss and a failed append would be replayed.
+      process.env.CADDY_ADMIN_URL = "http://caddy.local:2019/caddy-admin";
+      process.env.CADDY_MAX_RETRIES = "3";
+      const api = await import("../api.js");
+      let calls = 0;
+      globalThis.fetch = vi.fn(async () => {
+        calls++;
+        return new Response("boom", { status: 500 });
+      }) as any;
+
+      const res = await api.configPost("apps/http/servers/srv0/routes", {});
+      expect(res.ok).toBe(false);
+      expect(calls).toBe(1);
+    });
+
+    it("reports only the origin when the connection fails under a prefix", async () => {
+      process.env.CADDY_ADMIN_URL = "http://caddy.local:2019/caddy-admin";
+      const api = await import("../api.js");
+      globalThis.fetch = vi.fn(async () => {
+        throw new TypeError("fetch failed");
+      }) as any;
+
+      const res = await api.configGet("apps");
+      expect(res.error).toContain("http://caddy.local:2019");
+      expect(res.error).not.toContain("/caddy-admin");
+    });
+
+    it("lets a query string in CADDY_ADMIN_URL swallow the request path", async () => {
+      // Characterization, not an endorsement: a query in the base URL is
+      // operator error (no legitimate admin base URL carries one), and it
+      // corrupts every request -- the path lands inside the query. Pinned so
+      // that stripping it later is a deliberate change rather than a silent
+      // one. The surface that mattered is already handled: the connect-error
+      // message reports the origin only, so the token does not leak (see
+      // tools.test.ts).
+      process.env.CADDY_ADMIN_URL = "http://caddy.local:2019/some/path?token=secret";
+      const url = new URL(await captureUrl((a) => a.configGet("apps")));
+      expect(url.pathname).toBe("/some/path");
+      expect(url.search).toBe("?token=secret/config/apps");
+    });
+  });
+
   describe("ETag cache bounds", () => {
     it("evicts the oldest entry once the cache exceeds 256 paths", async () => {
       // An agent walking a large config issues hundreds of distinct GETs in one
@@ -1390,6 +1509,124 @@ describe("api", () => {
       expect(res.ok).toBe(false);
       expect(res.error).toContain("'..'");
       expect(called).toBe(0);
+    });
+  });
+
+  // Config keys are arbitrary strings, but they are interpolated into a URL.
+  // Before segment-encoding, a "#" or "?" in a key silently truncated the
+  // request path at the client: caddy_config_delete on
+  // "apps/http/servers/prod#1" sent DELETE /config/apps/http/servers/prod --
+  // it deleted the PARENT server and reported success. Nothing in the schema
+  // stops that either; config_get/set/delete take a bare string.
+  describe("config path percent-encoding", () => {
+    async function captureUrl(call: (a: typeof import("../api.js")) => Promise<unknown>) {
+      const api = await import("../api.js");
+      let raw = "";
+      globalThis.fetch = vi.fn(async (url: any) => {
+        raw = String(url);
+        return new Response("{}", { status: 200 });
+      }) as any;
+      await call(api);
+      return new URL(raw);
+    }
+
+    const hashKeyVerbs: Array<[string, (a: typeof import("../api.js")) => Promise<unknown>]> = [
+      ["configGet", (a) => a.configGet("apps/http/servers/prod#1")],
+      ["configPost", (a) => a.configPost("apps/http/servers/prod#1", {})],
+      ["configPut", (a) => a.configPut("apps/http/servers/prod#1", {})],
+      ["configPatch", (a) => a.configPatch("apps/http/servers/prod#1", {})],
+      ["configDelete", (a) => a.configDelete("apps/http/servers/prod#1")],
+    ];
+
+    it.each(hashKeyVerbs)("%s keeps a '#' key in the path instead of addressing its parent", async (_name, call) => {
+      const url = await captureUrl(call);
+      expect(url.pathname).toBe("/config/apps/http/servers/prod%231");
+      // The tell for the old bug: the remainder ended up here, not on the wire.
+      expect(url.hash).toBe("");
+    });
+
+    it("encodes '?' so a key cannot open a query string", async () => {
+      const url = await captureUrl((a) => a.configGet("apps/http/servers/a?b"));
+      expect(url.pathname).toBe("/config/apps/http/servers/a%3Fb");
+      expect(url.search).toBe("");
+    });
+
+    it("keeps '/' as the segment separator", async () => {
+      // Whole-string encodeURIComponent would send %2F here and address one
+      // top-level key whose name contains slashes.
+      const url = await captureUrl((a) => a.configGet("apps/http/servers/srv0"));
+      expect(url.pathname).toBe("/config/apps/http/servers/srv0");
+    });
+
+    it("still produces exactly /config/ for the root path", async () => {
+      const url = await captureUrl((a) => a.configGet(""));
+      expect(url.pathname).toBe("/config/");
+    });
+
+    it("leaves unreserved characters alone, including '..' inside a segment", async () => {
+      const url = await captureUrl((a) => a.configGet("apps/http/servers/my..name"));
+      expect(url.pathname).toBe("/config/apps/http/servers/my..name");
+    });
+
+    it("rejects '..' before encoding, and escapes a pre-encoded '%2e%2e' rather than decoding it", async () => {
+      // Order is load-bearing. rejectTraversal runs on the DECODED path, so a
+      // literal ".." never reaches fetch; and because encoding comes after,
+      // caller-supplied "%2e%2e" is escaped to %252e%252e -- Caddy decodes that
+      // back to the literal text "%2e%2e", never to a real ".." segment.
+      const api = await import("../api.js");
+      let called = 0;
+      let raw = "";
+      globalThis.fetch = vi.fn(async (url: any) => {
+        called++;
+        raw = String(url);
+        return new Response("{}", { status: 200 });
+      }) as any;
+
+      const rejected = await api.configGet("apps/../stop");
+      expect(rejected.ok).toBe(false);
+      expect(called).toBe(0);
+
+      await api.configGet("apps/%2e%2e/stop");
+      expect(new URL(raw).pathname).toBe("/config/apps/%252e%252e/stop");
+    });
+
+    it("encodes both the id and the subpath of an /id/ path", async () => {
+      expect((await captureUrl((a) => a.configByIdGet("route#1"))).pathname).toBe("/id/route%231");
+      expect((await captureUrl((a) => a.configByIdGet("route#1", "handle?x"))).pathname).toBe(
+        "/id/route%231/handle%3Fx",
+      );
+      expect((await captureUrl((a) => a.configByIdSet("route#1", {}, "PATCH", "handle?x"))).pathname).toBe(
+        "/id/route%231/handle%3Fx",
+      );
+      expect((await captureUrl((a) => a.configByIdDelete("route#1", "handle?x"))).pathname).toBe(
+        "/id/route%231/handle%3Fx",
+      );
+    });
+
+    it("encodes the CA id on both PKI endpoints", async () => {
+      expect((await captureUrl((a) => a.getPki("ca#1"))).pathname).toBe("/pki/ca/ca%231");
+      expect((await captureUrl((a) => a.getPkiCertificates("ca#1"))).pathname).toBe("/pki/ca/ca%231/certificates");
+    });
+
+    it("keys the ETag cache on the encoded path, so a read/write pair on a '#' key still sends If-Match", async () => {
+      // The cache key is the composed path. Encoding on one side only would
+      // silently drop optimistic concurrency for exactly these keys.
+      const api = await import("../api.js");
+      const calls: Array<{ method: string; ifMatch: string | null }> = [];
+      globalThis.fetch = vi.fn(async (_url: any, opts: any) => {
+        const method = opts?.method ?? "GET";
+        calls.push({ method, ifMatch: opts?.headers?.["If-Match"] ?? null });
+        if (method === "GET") {
+          return new Response("{}", { status: 200, headers: { ETag: "encoded-key-etag" } });
+        }
+        return new Response("", { status: 200 });
+      }) as any;
+
+      await api.configGet("encode-probe/prod#1");
+      await api.configPatch("encode-probe/prod#1", { listen: [":443"] });
+
+      expect(calls[1]?.method).toBe("PATCH");
+      expect(calls[1]?.ifMatch).toBe("encoded-key-etag");
     });
   });
 

--- a/src/tests/handlers.test.ts
+++ b/src/tests/handlers.test.ts
@@ -1,24 +1,38 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiResponse } from "../api.js";
 
-// Mock the api module — all tests control responses via these mocks
-vi.mock("../api.js", () => ({
-  configGet: vi.fn(),
-  configPost: vi.fn(),
-  configPut: vi.fn(),
-  configPatch: vi.fn(),
-  configDelete: vi.fn(),
-  loadConfig: vi.fn(),
-  adapt: vi.fn(),
-  stop: vi.fn(),
-  getUpstreams: vi.fn(),
-  getPki: vi.fn(),
-  getPkiCertificates: vi.fn(),
-  configByIdGet: vi.fn(),
-  configByIdSet: vi.fn(),
-  configByIdDelete: vi.fn(),
-  getMetrics: vi.fn(),
-}));
+// Mock the api module — all tests control responses via these mocks.
+//
+// Every REQUEST function is a vi.fn(); `isMissingConfigPath` deliberately is not.
+// It is a pure predicate over a response body, not I/O, so a stub would mean these
+// tests assert against a second copy of the marker matching instead of the one
+// production runs -- and the two could drift without anything failing. Take the
+// real implementation via importOriginal.
+//
+// The mock is WHOLESALE, so any export added to src/api.ts must be added here too:
+// an omission surfaces as "No <name> export is defined on the ../api.js mock" from
+// every test that touches the module, not as a targeted failure.
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("../api.js");
+  return {
+    configGet: vi.fn(),
+    configPost: vi.fn(),
+    configPut: vi.fn(),
+    configPatch: vi.fn(),
+    configDelete: vi.fn(),
+    loadConfig: vi.fn(),
+    adapt: vi.fn(),
+    stop: vi.fn(),
+    getUpstreams: vi.fn(),
+    getPki: vi.fn(),
+    getPkiCertificates: vi.fn(),
+    configByIdGet: vi.fn(),
+    configByIdSet: vi.fn(),
+    configByIdDelete: vi.fn(),
+    getMetrics: vi.fn(),
+    isMissingConfigPath: actual.isMissingConfigPath,
+  };
+});
 
 function ok<T>(data?: T): ApiResponse<T> {
   return { ok: true, status: 200, data };
@@ -247,6 +261,40 @@ describe("tool handler behavior", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('Server "srv99" does not exist');
+    });
+
+    it("treats a traversal failure as server-not-found -- the shape live Caddy sends", async () => {
+      // The marker that actually matters, and the one that was missing. Verified
+      // on 2.11.4: POST to a missing server's routes answers HTTP 500 with
+      // {"error":"invalid traversal path at: config/apps/http/servers/srv99/routes"}
+      // -- no 404, and no "key does not exist". Matching only the older markers
+      // made serverNotFoundError unreachable for its own headline case, so the
+      // operator got a raw Go error instead of the recipe for creating the server.
+      api.configPost.mockResolvedValue(
+        err(500, '{"error":"invalid traversal path at: config/apps/http/servers/srv99/routes"}'),
+      );
+
+      const result = await handler({ from: "app.local", to: ["localhost:3000"], server: "srv99" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Server "srv99" does not exist');
+    });
+
+    it("gives create-it advice that actually works", async () => {
+      // Every clause here was live-verified, and the ORIGINAL advice failed on two
+      // of them: mode "append" (POST) creates the key while the default
+      // "overwrite" (PATCH) answers "key does not exist", and "routes": [] must be
+      // present or the first route POST dies with "cannot unmarshal object into
+      // ... RouteList" -- POST creates a missing routes key as an object, not an
+      // array. Advice that does not work is worse than no advice: it costs the
+      // operator a round of debugging before they distrust it.
+      api.configPost.mockResolvedValue(err(404, "Not Found"));
+
+      const text = (await handler({ from: "app.local", to: ["localhost:3000"], server: "srv99" })).content[0].text;
+
+      expect(text).toContain('"routes": []');
+      expect(text).toContain('mode: "append"');
+      expect(text).toContain("caddy_load");
     });
 
     it("surfaces an ordinary validation failure verbatim, NOT as server-not-found", async () => {
@@ -669,6 +717,23 @@ describe("tool handler behavior", () => {
       // wire, and naming the likelier one is the 1.2.5 mistake.
       expect(result.content[0].text).toContain("is not configured, or its config is null");
       expect(result.content[0].text).toContain("caddy_list_servers");
+    });
+
+    it("answers a config-less instance with the create-it recipe, not a Go error", async () => {
+      // A traversal failure means a segment ABOVE the server name is missing, so
+      // this is the FIRST-RUN state: no apps/http tree at all. Verified on 2.11.4:
+      // HTTP 400 {"error":"invalid traversal path at: config/apps/http"}.
+      // Unlike the ambiguous null body, this one is decisive -- no parent chain
+      // means no server -- so asserting non-existence here is honest.
+      api.configGet.mockResolvedValue(err(400, '{"error":"invalid traversal path at: config/apps/http"}'));
+
+      const result = await handler({ server: "srv0" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Server "srv0" does not exist');
+      expect(result.content[0].text).toContain("caddy_load");
+      // The raw Go error must not be what the operator reads.
+      expect(result.content[0].text).not.toContain("invalid traversal path");
     });
 
     it("still renders a routeless server that really exists", async () => {
@@ -1720,6 +1785,35 @@ describe("tool handler behavior", () => {
       const result = await handler({});
 
       expect(result.content[0].text).toContain("No HTTP servers configured");
+    });
+
+    it("says the same thing on a config-less instance, which answers with an error", async () => {
+      // The empty state a first-time operator actually hits. A Caddy with no
+      // config has no `apps` key, so this read fails the path walk instead of
+      // returning {} -- verified on 2.11.4: HTTP 400 {"error":"invalid traversal
+      // path at: config/apps/http"}. Surfacing that raw made the tool whose whole
+      // job is "tell me what servers exist" answer a fresh instance with a Go
+      // internal error. The path is a fixed literal, so every way the walk can
+      // fail means no HTTP servers are configured and nothing else.
+      api.configGet.mockResolvedValue(err(400, '{"error":"invalid traversal path at: config/apps/http"}'));
+
+      const result = await handler({});
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toBe("No HTTP servers configured");
+    });
+
+    it("still surfaces a genuine read failure rather than claiming emptiness", async () => {
+      // The boundary: only a TRAVERSAL failure means "empty". An unreachable
+      // Caddy or an auth rejection must not be laundered into "no servers", which
+      // would tell an operator their production config had vanished.
+      api.configGet.mockResolvedValue(err(0, "Cannot connect to Caddy admin API at http://localhost:2019"));
+
+      const result = await handler({});
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Cannot connect");
+      expect(result.content[0].text).not.toContain("No HTTP servers configured");
     });
 
     it("renders a malformed server entry instead of throwing", async () => {

--- a/src/tests/handlers.test.ts
+++ b/src/tests/handlers.test.ts
@@ -82,6 +82,125 @@ describe("tool handler behavior", () => {
       expect(routeArg.handle[0].upstreams[0].dial).toBe("localhost:3000");
     });
 
+    it("an https:// upstream gets a TLS transport and defaults to port 443", async () => {
+      // The scheme is load-bearing: Caddy dials in the clear unless the HANDLER
+      // carries transport.tls, so reducing "https://backend" to { dial:
+      // "backend" } would silently downgrade the hop to the upstream. And once
+      // the scheme is stripped a dial is a socket address with nothing left to
+      // imply 443, so the port the caller meant has to be written out.
+      api.configPost.mockResolvedValue(ok());
+
+      await handler({ from: "api.local", to: ["https://backend.example.com"], server: "srv0" });
+
+      const routeArg = api.configPost.mock.calls[0][1];
+      expect(routeArg.handle[0]).toEqual({
+        handler: "reverse_proxy",
+        upstreams: [{ dial: "backend.example.com:443" }],
+        transport: { protocol: "http", tls: {} },
+      });
+    });
+
+    it("keeps an explicit port on an https:// upstream", async () => {
+      api.configPost.mockResolvedValue(ok());
+
+      await handler({ from: "api.local", to: ["https://backend.example.com:8443"], server: "srv0" });
+
+      const routeArg = api.configPost.mock.calls[0][1];
+      expect(routeArg.handle[0].upstreams).toEqual([{ dial: "backend.example.com:8443" }]);
+      expect(routeArg.handle[0].transport).toEqual({ protocol: "http", tls: {} });
+    });
+
+    it("brackets a bare IPv6 https:// upstream before appending the port", async () => {
+      // "::1:443" would parse as another address group, not host + port, so the
+      // literal has to be bracketed first. An already-bracketed one is left as
+      // written.
+      api.configPost.mockResolvedValue(ok());
+
+      await handler({ from: "api.local", to: ["https://::1"], server: "srv0" });
+      await handler({ from: "api.local", to: ["https://[::1]"], server: "srv0" });
+      await handler({ from: "api.local", to: ["https://[::1]:8443"], server: "srv0" });
+
+      const dials = api.configPost.mock.calls.map((c: any[]) => c[1].handle[0].upstreams[0].dial);
+      expect(dials).toEqual(["[::1]:443", "[::1]:443", "[::1]:8443"]);
+    });
+
+    it("carries one transport for a list of https:// upstreams", async () => {
+      api.configPost.mockResolvedValue(ok());
+
+      await handler({
+        from: "api.local",
+        to: ["https://a.example.com", "https://b.example.com:9443"],
+        server: "srv0",
+      });
+
+      const routeArg = api.configPost.mock.calls[0][1];
+      expect(routeArg.handle[0].upstreams).toEqual([{ dial: "a.example.com:443" }, { dial: "b.example.com:9443" }]);
+      expect(routeArg.handle[0].transport).toEqual({ protocol: "http", tls: {} });
+    });
+
+    it.each([
+      ["localhost:3000"],
+      ["http://localhost:3000"],
+    ])("omits `transport` entirely for a non-https upstream (%s)", async (upstream) => {
+      // `transport` present-but-empty is not the same config as `transport`
+      // absent, so the plain-http route must keep the exact handler shape it
+      // has always had rather than gaining an empty key.
+      api.configPost.mockResolvedValue(ok());
+
+      await handler({ from: "api.local", to: [upstream], server: "srv0" });
+
+      const handleArg = api.configPost.mock.calls[0][1].handle[0];
+      expect("transport" in handleArg).toBe(false);
+    });
+
+    it("refuses a `to` list that mixes https:// and non-https upstreams", async () => {
+      // transport is a property of the whole handler, not of one upstream, so
+      // either resolution would silently apply one entry's scheme to the
+      // other's connection. That decision stays with the caller.
+      const result = await handler({
+        from: "api.local",
+        to: ["https://secure.example.com", "localhost:3000"],
+        server: "srv0",
+      });
+
+      expect(api.configPost).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("mixes https:// and non-https");
+      expect(result.content[0].text).toContain("caddy_add_route");
+    });
+
+    it("refuses an empty `to` array rather than writing an upstream-less proxy", async () => {
+      // The zod schema rejects this before a real MCP call reaches the handler
+      // (see tools.test.ts), but the handler is also called directly here and
+      // by anything that bypasses validation -- a reverse_proxy with zero
+      // upstreams is a route that 502s every request.
+      const result = await handler({ from: "api.local", to: [], server: "srv0" });
+
+      expect(api.configPost).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("at least one upstream");
+    });
+
+    it.each(["   ", "\t", "http://", "https://"])("refuses `to`=[%j] -- no address left to dial", async (upstream) => {
+      // Each of these survives z.string().min(1) but cleans to an empty dial:
+      // whitespace-only, or a bare scheme with no authority. Writing { dial:
+      // "" } produces a route Caddy accepts and can never proxy.
+      const result = await handler({ from: "api.local", to: [upstream], server: "srv0" });
+
+      expect(api.configPost).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("no address to dial");
+    });
+
+    it("trims surrounding whitespace on upstreams, matching how `from` is trimmed", async () => {
+      api.configPost.mockResolvedValue(ok());
+
+      await handler({ from: "api.local", to: ["  https://backend.example.com:8443  "], server: "srv0" });
+
+      const routeArg = api.configPost.mock.calls[0][1];
+      expect(routeArg.handle[0].upstreams).toEqual([{ dial: "backend.example.com:8443" }]);
+    });
+
     it.each([
       "https://",
       " ",
@@ -364,6 +483,25 @@ describe("tool handler behavior", () => {
       expect(result.content[0].text).toContain("key does not exist");
       expect(result.content[0].text).not.toContain("does not exist. Use caddy_list_servers");
     });
+
+    it("first-create via id: POST failing for a non-parent reason surfaces verbatim", async () => {
+      // The GET 404 confirms the @id is absent, so the POST runs -- but a 400
+      // "duplicate ID" is a validation failure, not a missing server. Widening
+      // the parent-missing translation to swallow it would repeat the v1.2.5
+      // bug on this exact code path: a (status + body) shape that could come
+      // from more than one cause got translated, and the caller was sent to fix
+      // the wrong thing.
+      api.configByIdGet.mockResolvedValue(err(404, "unknown object ID"));
+      api.configPost.mockResolvedValue(
+        err(400, "duplicate ID 'some-id' found at apps/http/servers/srv0/routes/0 and .../routes/1"),
+      );
+
+      const result = await handler({ from: "api.local", to: ["localhost:3000"], server: "srv0", id: "some-id" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("duplicate ID 'some-id'");
+      expect(result.content[0].text).not.toContain("does not exist. Use caddy_list_servers");
+    });
   });
 
   // ─── caddy_add_route ──────────────────────────────────────────────────
@@ -507,6 +645,42 @@ describe("tool handler behavior", () => {
 
       const result = await handler({ server: "srv0" });
 
+      expect(result.content[0].text).toContain("no routes configured");
+    });
+
+    it.each([
+      ["a null body (unknown server, or a server whose config is null)", null],
+      ["an empty body", undefined],
+    ])("errors on %s rather than reporting an empty server", async (_label, body) => {
+      // Caddy answers an UNKNOWN server with 200 and a body of literal `null`,
+      // not a 404 -- verified against 2.11.4. So res.ok is true and the !ok guard
+      // never fires; before this check, `data || {}` collapsed null into an empty
+      // config and the tool cheerfully reported
+      //   Server "typo" (listen: default) -- no routes configured
+      // with no isError, telling an operator a live-looking server is empty and
+      // inviting them to overwrite it.
+      api.configGet.mockResolvedValue(ok(body));
+
+      const result = await handler({ server: "typo" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).not.toContain("no routes configured");
+      // Both causes named, neither asserted: the two are byte-identical on the
+      // wire, and naming the likelier one is the 1.2.5 mistake.
+      expect(result.content[0].text).toContain("is not configured, or its config is null");
+      expect(result.content[0].text).toContain("caddy_list_servers");
+    });
+
+    it("still renders a routeless server that really exists", async () => {
+      // The boundary the null check must not cross: `{}` is a REAL server with no
+      // routes yet -- exactly what caddy_config_set creates -- and Caddy returns
+      // it as an empty object, distinguishable from the null above. It must keep
+      // rendering as a normal empty listing, not as the not-configured error.
+      api.configGet.mockResolvedValue(ok({}));
+
+      const result = await handler({ server: "srv0" });
+
+      expect(result.isError).toBeFalsy();
       expect(result.content[0].text).toContain("no routes configured");
     });
 
@@ -805,6 +979,17 @@ describe("tool handler behavior", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("value is required");
     });
+
+    it("names the sub-path in the delete refusal when one was supplied", async () => {
+      // A subpath delete removes only part of the identified object, so the
+      // refusal has to say WHICH part -- naming the @id alone reads as though
+      // the whole route were about to go, which is a different consent.
+      const result = await handler({ id: "my-route", action: "delete", subpath: "handle/0" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('@id="my-route" subpath "handle/0"');
+      expect(api.configByIdDelete).not.toHaveBeenCalled();
+    });
   });
 
   // ─── caddy_tls (PATCH happy-path + safe-fallback branches) ────────────
@@ -1004,6 +1189,63 @@ describe("tool handler behavior", () => {
       expect(api.configPut).not.toHaveBeenCalled();
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("issuers[0]");
+    });
+
+    // Branch 3b: shape is fine, but the issuer sitting at policies[0].issuers[0]
+    // is not an ACME one. `email` / `ca` / `profile` are fields of the acme
+    // issuer module only, so merging them in writes a foreign key. `internal`
+    // (Caddy's local CA) is the dangerous case rather than a hypothetical: it
+    // carries its OWN `ca` key naming a PKI CA id, so set_acme_ca would quietly
+    // repoint the local CA at an ACME directory URL.
+    it.each([
+      ["set_email", { email: "test@example.com" }],
+      ["set_acme_ca", { ca: "https://acme.example.com/dir" }],
+      ["set_acme_profile", { profile: "shortlived" }],
+    ])("PATCH fails + issuers[0] is a non-ACME issuer -> %s refuses without writing", async (action, args) => {
+      subpathPatchFails();
+      api.configGet.mockResolvedValue(
+        ok({ automation: { policies: [{ issuers: [{ module: "internal", ca: "local" }] }] } }),
+      );
+
+      const result = await handler({ action, ...(args as Record<string, string>) });
+
+      // No write of any kind: not the whole-object merge PATCH, not a create.
+      expect(mergeCall()).toBeUndefined();
+      expect(api.configPost).not.toHaveBeenCalled();
+      expect(api.configPut).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Refusing to write an ACME field onto a non-ACME issuer");
+      // The message names what was actually found, so the caller can tell a
+      // wrong-issuer refusal from the wrong-shape one above.
+      expect(result.content[0].text).toContain('module is "internal", not "acme"');
+      expect(result.content[0].text).toContain("caddy_config_set");
+    });
+
+    it("PATCH fails + issuers[0] carries no module key -> refuses, reporting it as absent", async () => {
+      // An issuer with no `module` is not implicitly acme -- Caddy needs the key
+      // to know which module to load -- so this refuses too, and says "absent"
+      // rather than quoting a value that isn't there.
+      subpathPatchFails();
+      api.configGet.mockResolvedValue(ok({ automation: { policies: [{ issuers: [{ email: "old@example.com" }] }] } }));
+
+      const result = await handler({ action: "set_email", email: "test@example.com" });
+
+      expect(mergeCall()).toBeUndefined();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('module is absent, not "acme"');
+    });
+
+    it("still merges when the issuer IS acme (the module guard does not block the happy path)", async () => {
+      // Counterpart to the refusals above: the guard must reject non-ACME
+      // issuers WITHOUT costing the ordinary merge, which is the path
+      // set_acme_profile takes on every fresh issuer.
+      subpathPatchFails();
+      api.configGet.mockResolvedValue(ok({ automation: { policies: [{ issuers: [{ module: "acme" }] }] } }));
+
+      const result = await handler({ action: "set_acme_profile", profile: "shortlived" });
+
+      expect(result.isError).toBeFalsy();
+      expect(mergeCall()?.[1].automation.policies[0].issuers[0]).toEqual({ module: "acme", profile: "shortlived" });
     });
 
     // Failure paths through bothErrors.
@@ -1317,6 +1559,47 @@ describe("tool handler behavior", () => {
       expect(result.content[0].text).toContain("TLS: enabled");
     });
 
+    it.each([
+      [":443", "auto (HTTPS)"],
+      [":80", "off (HTTP only)"],
+    ])("an EMPTY tls_connection_policies falls through to the listen heuristic (%s -> %s)", async (port, expected) => {
+      // `tls_connection_policies: []` configures nothing, so it has to read the
+      // same as an absent key. Reporting "enabled" off the key's mere presence
+      // told the caller TLS was explicitly configured when the array was empty.
+      api.configGet.mockResolvedValue(
+        ok({
+          apps: {
+            http: {
+              servers: { srv0: { listen: [port], routes: [], tls_connection_policies: [] } },
+            },
+          },
+        }),
+      );
+
+      const result = await handler({});
+      expect(result.content[0].text).toContain(`TLS: ${expected}`);
+      expect(result.content[0].text).not.toContain("TLS: enabled");
+    });
+
+    it("keeps the 'enabled' reading for a present-but-non-array tls_connection_policies", async () => {
+      // Deliberately NOT folded into the empty-array case: a non-array value is
+      // a malformed config we cannot interpret, and "something is configured
+      // here" is the safer summary than silently calling it off. Pinned so a
+      // future tightening of the empty-array fix is a deliberate change.
+      api.configGet.mockResolvedValue(
+        ok({
+          apps: {
+            http: {
+              servers: { srv0: { listen: [":80"], routes: [], tls_connection_policies: { alpn: ["h2"] } } },
+            },
+          },
+        }),
+      );
+
+      const result = await handler({});
+      expect(result.content[0].text).toContain("TLS: enabled");
+    });
+
     it("shows ACME email when present at policies[0].issuers[0].email", async () => {
       api.configGet.mockResolvedValue(
         ok({
@@ -1359,6 +1642,33 @@ describe("tool handler behavior", () => {
       expect(text).not.toContain("second@example.com");
       expect(text).not.toContain("other-policy@example.com");
     });
+
+    it("renders a NULL config body as running with no servers", async () => {
+      // A running Caddy 2.11.4 that has never been configured answers
+      // GET /config/ with a literal `null`, which api.ts parses to data: null.
+      // The sibling tests pass {} and { apps: {} }, so neither exercises the
+      // nullish fallback that keeps this from dereferencing null.
+      api.configGet.mockResolvedValue(ok(null));
+
+      const result = await handler({});
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain("Caddy is running");
+      expect(result.content[0].text).toContain("No HTTP servers configured");
+    });
+
+    it("does not throw when policies[0] is null", async () => {
+      // Reachable on a live instance despite looking impossible: loading
+      // {"apps":{"tls":{"automation":{"policies":[null]}}}} panics Caddy inside
+      // (*AutomationPolicy).Provision, but the raw config is ALREADY swapped in
+      // by then -- so the next GET /config/ really does return policies: [null].
+      api.configGet.mockResolvedValue(ok({ apps: { tls: { automation: { policies: [null] } } } }));
+
+      const result = await handler({});
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).not.toContain("ACME email");
+    });
   });
 
   // ─── caddy_list_servers ───────────────────────────────────────────────
@@ -1386,6 +1696,22 @@ describe("tool handler behavior", () => {
 
       expect(text).toContain("srv0: 2 route(s), listen: :443");
       expect(text).toContain("api: 1 route(s), listen: :8080");
+    });
+
+    it("reads an empty tls_connection_policies off the listen port here too", async () => {
+      // caddy_status and caddy_list_servers share describeServer, so the empty-
+      // array fix has to show up on both surfaces -- this is the second one.
+      api.configGet.mockResolvedValue(
+        ok({
+          srv0: { listen: [":443"], routes: [], tls_connection_policies: [] },
+          plain: { listen: [":80"], routes: [], tls_connection_policies: [] },
+        }),
+      );
+
+      const text = (await handler({})).content[0].text;
+
+      expect(text).toContain("srv0: 0 route(s), listen: :443, TLS: auto (HTTPS)");
+      expect(text).toContain("plain: 0 route(s), listen: :80, TLS: off (HTTP only)");
     });
 
     it("shows message when no servers configured", async () => {
@@ -1416,6 +1742,18 @@ describe("tool handler behavior", () => {
       expect(text).toContain("broken: 0 route(s), listen: default");
       expect(text).toContain("alsoBroken: 0 route(s), listen: default");
       expect(text).toContain("arrayish: 0 route(s), listen: default");
+    });
+
+    it("reports no servers when the servers key resolves to NULL", async () => {
+      // Verified against a live Caddy 2.11.4: with {"apps":{"http":{}}} loaded,
+      // GET /config/apps/http/servers answers 200 null -- not 400, not {} -- so
+      // the `?? {}` fallback sits on an ordinary path, not a defensive one.
+      api.configGet.mockResolvedValue(ok(null));
+
+      const result = await handler({});
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain("No HTTP servers configured");
     });
   });
 
@@ -1620,6 +1958,18 @@ describe("tool handler behavior", () => {
       const text = result.content[0].text;
 
       expect(text).not.toContain("# EOF");
+    });
+
+    it("emits OK rather than the literal string 'undefined' for a body-less metrics response", async () => {
+      // api.ts yields data: undefined for any empty 200, and String(undefined)
+      // would put the word "undefined" in front of the caller as though it were
+      // the metrics text.
+      api.getMetrics.mockResolvedValue(ok(undefined));
+
+      const result = await handler({});
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toBe("OK");
     });
   });
 
@@ -1917,6 +2267,67 @@ describe("tool handler behavior", () => {
       }
       expect(listSnapshots()).toHaveLength(0);
     });
+
+    it("save surfaces the API error when the pre-save read fails", async () => {
+      // An unreachable or erroring admin API is a different problem from a
+      // malformed config body. Reporting "not a JSON object" for a 503 would
+      // send the caller off to inspect a config they never managed to read.
+      const { listSnapshots } = await import("../snapshots.js");
+      api.configGet.mockResolvedValue(err(503, "down"));
+
+      const result = await handler({ action: "save", index: 0, confirm: false });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("down");
+      expect(result.content[0].text).not.toContain("empty or not a JSON object");
+      expect(listSnapshots()).toHaveLength(0);
+    });
+
+    it("apply succeeds when the PRE-revert read fails, pushing no rollback-forward snapshot", async () => {
+      // Realistic rather than defensive: Caddy restarts its admin listener on
+      // every /load, so the read that precedes a revert can legitimately fail.
+      // The load is what decides success, and a config that was never read
+      // cannot be pushed as a rollback-forward target -- so the ring still
+      // holds exactly the one snapshot the operator was reverting to.
+      const { saveSnapshot, listSnapshots } = await import("../snapshots.js");
+      const target = { apps: { intended: true } };
+      saveSnapshot(target, "caddy_load");
+
+      api.configGet.mockResolvedValue(err(0, "fetch failed"));
+      api.loadConfig.mockResolvedValue(ok());
+
+      const result = await handler({ action: "apply", index: 0, confirm: true });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain("Reverted to snapshot [0]");
+      // The success message must SAY the safety net was skipped. Reporting a
+      // bare success here would leave the operator believing they can undo this
+      // revert, at the one moment they cannot -- the config just replaced went
+      // unrecorded, so there is nothing to go back to.
+      expect(result.content[0].text).toContain("no roll-forward snapshot was captured");
+      expect(result.content[0].text).toContain("cannot be undone");
+      const snaps = listSnapshots();
+      expect(snaps).toHaveLength(1);
+      expect(snaps[0].trigger).toBe("caddy_load");
+      expect(snaps[0].config).toEqual(target);
+    });
+
+    it("does not warn about the roll-forward snapshot when it was captured", async () => {
+      // The other half of the pair: on the ordinary path the warning must be
+      // ABSENT, or it becomes noise operators learn to scroll past.
+      const { saveSnapshot, listSnapshots } = await import("../snapshots.js");
+      saveSnapshot({ apps: { intended: true } }, "caddy_load");
+
+      api.configGet.mockResolvedValue(ok({ apps: { current: true } }));
+      api.loadConfig.mockResolvedValue(ok());
+
+      const result = await handler({ action: "apply", index: 0, confirm: true });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain("Reverted to snapshot [0]");
+      expect(result.content[0].text).not.toContain("Warning");
+      expect(listSnapshots()[0].trigger).toBe("caddy_revert");
+    });
   });
 
   // ─── caddy_remove_route ───────────────────────────────────────────────
@@ -1945,11 +2356,53 @@ describe("tool handler behavior", () => {
     });
 
     it("deletes by @id when id is given", async () => {
+      // The @id path is now GET-then-DELETE, not a bare DELETE: the tool reads
+      // the object first and only removes it once it is route-shaped (top-level
+      // `handle` array). @ids are config-global in Caddy, so without that read a
+      // colliding id from another subsystem would be deleted as if it were a
+      // route -- and a delete, unlike a botched write, leaves nothing to inspect.
+      api.configByIdGet.mockResolvedValue(
+        ok({ "@id": "api-v2", match: [{ host: ["api.local"] }], handle: [{ handler: "reverse_proxy" }] }),
+      );
       api.configByIdDelete.mockResolvedValue(ok({}));
       const result = await handler({ id: "api-v2", confirm: true });
+      expect(api.configByIdGet).toHaveBeenCalledWith("api-v2");
       expect(result.isError).toBeFalsy();
       expect(api.configByIdDelete).toHaveBeenCalledWith("api-v2");
       expect(result.content[0].text).toContain('@id="api-v2"');
+    });
+
+    it("refuses to delete when @id resolves to a non-route object", async () => {
+      // Same collision the write path guards, with worse consequences: the id
+      // resolves to an @id'd TLS issuer, and deleting it would take the
+      // instance's ACME configuration with it. Refuse, and name the deliberate
+      // way to remove it if that is genuinely what the caller meant.
+      api.configByIdGet.mockResolvedValue(ok({ "@id": "api-v2", module: "acme", email: "ops@example.com" }));
+
+      const result = await handler({ id: "api-v2", confirm: true });
+
+      expect(api.configByIdGet).toHaveBeenCalledWith("api-v2");
+      expect(api.configByIdDelete).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("non-route config object");
+      expect(result.content[0].text).toContain("config-global");
+      expect(result.content[0].text).toContain("caddy_config_by_id");
+    });
+
+    it("surfaces a failing @id GET verbatim instead of the wrong-shape refusal", async () => {
+      // An @id that does not resolve AT ALL is a different problem from one that
+      // resolves to the wrong kind of object, and only the caller can tell which
+      // they meant. The API's own error has to survive: translating a 404 into
+      // "resolves to a non-route config object" would describe an object that
+      // isn't there.
+      api.configByIdGet.mockResolvedValue(err(404, "unknown object ID 'ghost-route'"));
+
+      const result = await handler({ id: "ghost-route", confirm: true });
+
+      expect(api.configByIdDelete).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("unknown object ID 'ghost-route'");
+      expect(result.content[0].text).not.toContain("non-route config object");
     });
 
     it("rejects out-of-range index", async () => {
@@ -1971,6 +2424,20 @@ describe("tool handler behavior", () => {
       const result = await handler({ index: 1, server: "srv0", confirm: true });
       expect(result.isError).toBeFalsy();
       expect(api.configDelete).toHaveBeenCalledWith("apps/http/servers/srv0/routes/1");
+    });
+
+    it("names an INDEX target in the confirm=false refusal", async () => {
+      // The refusal test above passes an id, so only the @id half of the target
+      // ternary ever ran. Index is the mode that is NOT idempotent -- Caddy
+      // re-packs the routes array after a removal -- so its refusal has to name
+      // both the index and the server the caller is about to act on.
+      const result = await handler({ index: 3, server: "srv1", confirm: false });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Refusing to remove route 3 on server "srv1"');
+      // Nothing may be read or deleted before the caller confirms.
+      expect(api.configGet).not.toHaveBeenCalled();
+      expect(api.configDelete).not.toHaveBeenCalled();
     });
   });
 
@@ -2158,9 +2625,13 @@ describe("tool handler behavior", () => {
     });
 
     it("surfaces the api error verbatim when by-@id delete fails after confirm", async () => {
+      // The shape guard has to pass for the DELETE to be reached at all, so the
+      // GET returns a real route here -- this test is about the delete itself
+      // failing (concurrency, transport, validation), not about the guard.
+      api.configByIdGet.mockResolvedValue(ok({ "@id": "doomed-route", match: [], handle: [] }));
       api.configByIdDelete.mockResolvedValue(err(500, "id-delete-failed"));
-      const result = await handler({ id: "missing-route", confirm: true });
-      expect(api.configByIdDelete).toHaveBeenCalledWith("missing-route");
+      const result = await handler({ id: "doomed-route", confirm: true });
+      expect(api.configByIdDelete).toHaveBeenCalledWith("doomed-route");
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("id-delete-failed");
     });
@@ -2295,6 +2766,73 @@ describe("tool handler behavior", () => {
       expect(text).toContain("error(503)");
       expect(text).toContain("encode");
       expect(text).toContain("headers");
+    });
+
+    it("renders a null entry INSIDE a route's match array as catch-all", async () => {
+      // `match: [null]` passes caddy validate 2.11.4, so a live config can hold
+      // one. Reading .host off it throws inside the summary loop, and that throw
+      // takes the listing for every OTHER route on the server down with it.
+      // Sibling tests cover a null ROUTE and a non-array match, never this.
+      api.configGet.mockResolvedValue(
+        ok({
+          listen: [":443"],
+          routes: [{ match: [null], handle: [{ handler: "static_response", status_code: 200 }] }],
+        }),
+      );
+
+      const result = await handler({ server: "srv0" });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain("catch-all → static_response(200)");
+    });
+
+    it.each([[{}], [{ max_requests: 5 }]])("renders %j as ? inside reverse_proxy(...)", async (upstream) => {
+      // An upstream is only required to be an object -- Caddy fills `dial` when
+      // adapting a Caddyfile, but a hand-written JSON config can omit it. The
+      // placeholder keeps the summary line a summary line instead of dumping
+      // the raw object into it.
+      // Deliberately NOT covered: upstreams: [null]. That panics Caddy at
+      // provision, so the admin API can never serve the shape the sibling
+      // branch guards -- it is genuinely unreachable.
+      api.configGet.mockResolvedValue(
+        ok({
+          listen: [":443"],
+          routes: [{ match: [{ host: ["a.local"] }], handle: [{ handler: "reverse_proxy", upstreams: [upstream] }] }],
+        }),
+      );
+
+      expect((await handler({ server: "srv0" })).content[0].text).toContain("reverse_proxy(?)");
+    });
+
+    it.each([
+      [{ handler: "file_server", root: "/var/www" }, "file_server(/var/www)"],
+      [{ handler: "file_server" }, "file_server(.)"],
+    ])("renders %j as %s", async (handle, expected) => {
+      // Every other handler arm has a formatter test; file_server had none,
+      // which left the most common static-site route unpinned. A root-less
+      // file_server is the ordinary shape, not a malformed one -- Caddy
+      // defaults the root to the working directory.
+      api.configGet.mockResolvedValue(
+        ok({ listen: [":80"], routes: [{ match: [{ path: ["/static"] }], handle: [handle] }] }),
+      );
+
+      expect((await handler({ server: "srv0" })).content[0].text).toContain(expected);
+    });
+
+    it.each([
+      [{ handler: "rewrite", strip_path_prefix: "/api" }, "rewrite(...)"],
+      [{ handler: "authentication" }, "auth(...)"],
+      [{ handler: "error", status_code: "{http.error.status_code}" }, "error(...)"],
+    ])("falls back to a placeholder for %j", async (handle, expected) => {
+      // All three pass caddy validate 2.11.4, so none is hypothetical. The
+      // `error` one is the non-obvious case: status_code arrives as a JSON
+      // STRING (a Caddy WeakString holding a placeholder), which is exactly why
+      // that arm tests typeof === "number" rather than mere presence.
+      api.configGet.mockResolvedValue(
+        ok({ listen: [":443"], routes: [{ match: [{ path: ["/x"] }], handle: [handle] }] }),
+      );
+
+      expect((await handler({ server: "srv0" })).content[0].text).toContain(expected);
     });
   });
 
@@ -2714,6 +3252,25 @@ describe("tool handler behavior", () => {
       result = await handler();
       expect(result.contents[0].mimeType).toBe("text/plain");
       expect(result.contents[0].text).toMatch(/^Error: /);
+    });
+
+    it.each([
+      ["caddy-config", "configGet"],
+      ["caddy-upstreams", "getUpstreams"],
+      ["caddy-servers", "configGet"],
+      ["caddy-metrics", "getMetrics"],
+    ])("%s: falls back to the status code when the failure carries no error text", async (resource, method) => {
+      // `error` is optional on ApiResponse -- only the failure paths api.ts
+      // builds itself are guaranteed to fill it, so a body-less non-2xx can
+      // arrive without one. Interpolating it bare rendered the literal string
+      // "Error: undefined" to the client, which says nothing; the status at
+      // least reports what the server answered.
+      (api as any)[method].mockResolvedValueOnce({ ok: false, status: 503 });
+      const handler = await getResourceHandler(resource);
+      const result = await handler();
+
+      expect(result.contents[0].mimeType).toBe("text/plain");
+      expect(result.contents[0].text).toBe("Error: HTTP 503");
     });
   });
 });

--- a/src/tests/handlers.test.ts
+++ b/src/tests/handlers.test.ts
@@ -2305,11 +2305,43 @@ describe("tool handler behavior", () => {
       // revert, at the one moment they cannot -- the config just replaced went
       // unrecorded, so there is nothing to go back to.
       expect(result.content[0].text).toContain("no roll-forward snapshot was captured");
-      expect(result.content[0].text).toContain("cannot be undone");
+      expect(result.content[0].text).toContain("cannot be rolled back to the config it replaced");
+      // The READ FAILED here, so the warning must say so -- and must not use the
+      // wording reserved for a read that succeeded with a non-object body.
+      expect(result.content[0].text).toContain("could not be read");
+      expect(result.content[0].text).not.toContain("empty or not a JSON object");
       const snaps = listSnapshots();
       expect(snaps).toHaveLength(1);
       expect(snaps[0].trigger).toBe("caddy_load");
       expect(snaps[0].config).toEqual(target);
+    });
+
+    it.each([
+      ["a null body", null],
+      ["a bare string", "not-a-config"],
+      ["an array", []],
+    ])("blames the body, not the admin API, when the pre-revert read returns %s", async (_label, body) => {
+      // The snapshot is skipped for TWO distinguishable reasons and the warning
+      // must not conflate them. Here the read SUCCEEDED -- Caddy answers a
+      // config-less instance with HTTP 200 and a literal `null` -- so claiming it
+      // "could not be read" would send the operator chasing a connectivity or
+      // admin-listener fault that does not exist. Naming a cause the signal does
+      // not support is the mistake that got 1.2.5 deprecated.
+      const { saveSnapshot, listSnapshots } = await import("../snapshots.js");
+      saveSnapshot({ apps: { intended: true } }, "caddy_load");
+
+      api.configGet.mockResolvedValue(ok(body));
+      api.loadConfig.mockResolvedValue(ok());
+
+      const result = await handler({ action: "apply", index: 0, confirm: true });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toContain("Reverted to snapshot [0]");
+      expect(result.content[0].text).toContain("empty or not a JSON object");
+      expect(result.content[0].text).not.toContain("could not be read");
+      // Still no roll-forward snapshot -- only the wording differs.
+      expect(listSnapshots()).toHaveLength(1);
+      expect(listSnapshots()[0].trigger).toBe("caddy_load");
     });
 
     it("does not warn about the roll-forward snapshot when it was captured", async () => {

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -1,6 +1,9 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { ApiResponse } from "../api.js";
 import * as api from "../api.js";
+import { registerAdaptTools } from "../tools/adapt.js";
+import { registerOperationalTools } from "../tools/operational.js";
+import { registerRouteTools } from "../tools/routes.js";
 
 const RUN = process.env.CADDY_MCP_INTEGRATION === "1";
 
@@ -400,5 +403,128 @@ describe.skipIf(!RUN)("integration: live Caddy admin API", () => {
 
     const getAfter = await api.configByIdGet("integration-route");
     expect(getAfter.ok).toBe(false);
+  });
+
+  // Tool handlers, not the api module. Each case below turns on a response
+  // shape only a real Caddy produces -- a failed path traversal, a server
+  // object with no keys, an adapter syntax error -- so the mocked suite in
+  // tools.test.ts (which feeds hand-built 200s) can never reach them.
+  describe("tool handlers against live Caddy", () => {
+    type ToolResult = { isError?: boolean; content: Array<{ type: string; text: string }> };
+
+    /**
+     * Register a tool module against a stand-in server and return one tool's
+     * handler (argument 5 of server.tool), the same way tools.test.ts does.
+     *
+     * Calling the handler directly bypasses zod, so every argument has to be
+     * passed explicitly -- schema defaults like server="srv0" do not apply.
+     */
+    function getHandler(register: (server: any) => void, name: string) {
+      const calls: any[][] = [];
+      register({ tool: (...args: any[]) => calls.push(args), resource: () => {} });
+      const handler = calls.find((c) => c[0] === name)?.[4];
+      if (typeof handler !== "function") throw new Error(`tool ${name} was not registered`);
+      return handler as (args: Record<string, unknown>) => Promise<ToolResult>;
+    }
+
+    // A server GET that fails must be surfaced verbatim rather than falling
+    // through to the summary path. On an instance carrying no apps/http at all,
+    // Caddy answers 400 "invalid traversal path" -- if that guard regressed the
+    // tool would print "no routes configured" for a server it never read,
+    // telling an operator a live server is empty and inviting an overwrite.
+    //
+    // This covers the GET-FAILS path -- reachable only while apps/http/servers is
+    // absent entirely, which makes Caddy reject the traversal. The far more common
+    // mistyped-name case takes the null path pinned in the next test.
+    it("caddy_list_routes surfaces a failed server GET rather than reporting an empty server", async () => {
+      const handler = getHandler(registerRouteTools, "caddy_list_routes");
+      const result = await handler({ server: "does-not-exist" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("invalid traversal path");
+      expect(result.content[0].text).not.toContain("no routes configured");
+    });
+
+    // The live half of the null-body bug. Only a real Caddy produces this shape,
+    // which is why it went unnoticed: every mocked fixture returned a populated
+    // 200, so no test ever saw an unknown server answered with `200 null`.
+    it("caddy_list_routes errors on a mistyped server name once servers exist", async () => {
+      const loaded = await loadAndSettle({
+        apps: { http: { servers: { real: { listen: [":18871"], routes: [] } } } },
+      });
+      assertOk(loaded, "loadConfig one real server");
+
+      // Confirm the premise against this Caddy rather than trusting the note:
+      // an unknown key really is 200 + null, not a 404.
+      const probe = await api.configGet("apps/http/servers/typo");
+      expect(probe.ok).toBe(true);
+      expect(probe.data).toBeNull();
+
+      const handler = getHandler(registerRouteTools, "caddy_list_routes");
+      const result = await handler({ server: "typo" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("is not configured, or its config is null");
+      expect(result.content[0].text).not.toContain("no routes configured");
+
+      // The real neighbour must still list normally -- the guard keys on the
+      // response body, not on the name.
+      const good = await handler({ server: "real" });
+      expect(good.isError).toBeFalsy();
+      expect(good.content[0].text).toContain("no routes configured");
+    });
+
+    // 2.11.4 accepts a server object with no keys at all, and that is exactly
+    // the shape serverNotFoundError tells operators to create. Without the
+    // Array.isArray guards, routes.length would throw on undefined.
+    it("caddy_list_routes reports a keyless or empty server instead of crashing", async () => {
+      const noKeys = await loadAndSettle({ apps: { http: { servers: { srv0: {} } } } });
+      assertOk(noKeys, "loadConfig keyless server");
+
+      const handler = getHandler(registerRouteTools, "caddy_list_routes");
+      const bare = await handler({ server: "srv0" });
+      expect(bare.isError).toBeFalsy();
+      expect(bare.content[0].text).toContain("Server srv0 (listen: default)");
+      expect(bare.content[0].text).toContain("no routes configured");
+
+      // Present-but-empty listen/routes take the same path: an empty listen
+      // array still renders as "default", not as a trailing "listen: ".
+      const empty = await loadAndSettle({ apps: { http: { servers: { srv0: { listen: [], routes: [] } } } } });
+      assertOk(empty, "loadConfig empty listen and routes");
+
+      const emptied = await handler({ server: "srv0" });
+      expect(emptied.isError).toBeFalsy();
+      expect(emptied.content[0].text).toContain("Server srv0 (listen: default)");
+      expect(emptied.content[0].text).toContain("no routes configured");
+    });
+
+    // On an instance with no apps/http, GET /config/apps/http/servers is a 400,
+    // not an empty object -- so caddy_list_servers reaches formatResult and
+    // never gets to say "No HTTP servers configured". Every mocked test feeds
+    // an ok({...}), so no test has seen what a bare Caddy actually answers.
+    it("caddy_list_servers surfaces the empty-instance failure rather than 'No HTTP servers configured'", async () => {
+      const handler = getHandler(registerOperationalTools, "caddy_list_servers");
+      const result = await handler({});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("invalid traversal path");
+      expect(result.content[0].text).not.toContain("No HTTP servers configured");
+    });
+
+    // An adapter failure has to come back as an error result. If this guard
+    // regressed, a typo'd Caddyfile would render as "OK (no output)" -- the
+    // undefined `result` field of an error body -- and an operator would
+    // believe it converted cleanly and go on to load it.
+    it("caddy_adapt reports an adapter failure as an error, not a clean conversion", async () => {
+      const handler = getHandler(registerAdaptTools, "caddy_adapt");
+
+      const malformed = await handler({ config: "this is not { a valid", adapter: "caddyfile" });
+      expect(malformed.isError).toBe(true);
+      expect(malformed.content[0].text).toContain("syntax error");
+      expect(malformed.content[0].text).not.toContain("OK (no output)");
+
+      // Same for an adapter this Caddy build does not carry: the schema accepts
+      // the name, only the server can reject it.
+      const unknownAdapter = await handler({ config: "server {}", adapter: "nginx" });
+      expect(unknownAdapter.isError).toBe(true);
+      expect(unknownAdapter.content[0].text).toContain("unrecognized config adapter");
+    });
   });
 });

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -433,15 +433,58 @@ describe.skipIf(!RUN)("integration: live Caddy admin API", () => {
     // tool would print "no routes configured" for a server it never read,
     // telling an operator a live server is empty and inviting an overwrite.
     //
-    // This covers the GET-FAILS path -- reachable only while apps/http/servers is
-    // absent entirely, which makes Caddy reject the traversal. The far more common
-    // mistyped-name case takes the null path pinned in the next test.
-    it("caddy_list_routes surfaces a failed server GET rather than reporting an empty server", async () => {
+    // The GET-FAILS path, reachable while apps/http/servers is absent entirely.
+    // A traversal failure is DECISIVE -- no parent chain means no server -- so
+    // unlike the ambiguous null body below, asserting non-existence is honest,
+    // and the operator gets the create-it recipe instead of a Go error.
+    it("caddy_list_routes answers a config-less instance with the create-it recipe", async () => {
       const handler = getHandler(registerRouteTools, "caddy_list_routes");
       const result = await handler({ server: "does-not-exist" });
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("invalid traversal path");
+      expect(result.content[0].text).toContain('Server "does-not-exist" does not exist');
+      expect(result.content[0].text).toContain("caddy_load");
+      expect(result.content[0].text).not.toContain("invalid traversal path");
       expect(result.content[0].text).not.toContain("no routes configured");
+    });
+
+    // The write-side counterpart, and the case isParentMissing exists for. Live
+    // Caddy answers a POST under a missing server with 500 "invalid traversal
+    // path", never the 404 / "key does not exist" every mocked fixture used --
+    // so serverNotFoundError was unreachable here and callers saw the raw error.
+    it("caddy_reverse_proxy names the missing server instead of leaking a Go error", async () => {
+      const loaded = await loadAndSettle({
+        apps: { http: { servers: { srv0: { listen: [":18875"], routes: [] } } } },
+      });
+      assertOk(loaded, "loadConfig one real server");
+
+      const handler = getHandler(registerRouteTools, "caddy_reverse_proxy");
+      const result = await handler({ from: "app.local", to: ["localhost:3000"], server: "nosuch" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Server "nosuch" does not exist');
+      expect(result.content[0].text).not.toContain("invalid traversal path");
+    });
+
+    // The advice has to WORK, not merely read well: following it verbatim must
+    // produce a server that accepts its first route. The original text omitted
+    // both `routes: []` and mode "append", so an operator who followed it hit
+    // "cannot unmarshal object into ... RouteList" on their very next call.
+    it("the create-it advice actually produces a usable server", async () => {
+      const loaded = await loadAndSettle({ apps: { http: { servers: { srv0: { listen: [":18876"], routes: [] } } } } });
+      assertOk(loaded, "loadConfig seed server");
+
+      // Exactly what serverNotFoundError tells the operator to do.
+      const create = await api.configPost("apps/http/servers/fresh", {
+        listen: [":18877"],
+        routes: [],
+        automatic_https: { disable_redirects: true },
+      });
+      assertOk(create, "create server per the advice");
+
+      const handler = getHandler(registerRouteTools, "caddy_reverse_proxy");
+      const added = await handler({ from: "/api", to: ["localhost:3000"], server: "fresh" });
+      expect(added.isError, added.content?.[0]?.text).toBeFalsy();
+      expect(added.content[0].text).toContain("Route added");
     });
 
     // The live half of the null-body bug. Only a real Caddy produces this shape,
@@ -496,16 +539,17 @@ describe.skipIf(!RUN)("integration: live Caddy admin API", () => {
       expect(emptied.content[0].text).toContain("no routes configured");
     });
 
-    // On an instance with no apps/http, GET /config/apps/http/servers is a 400,
-    // not an empty object -- so caddy_list_servers reaches formatResult and
-    // never gets to say "No HTTP servers configured". Every mocked test feeds
-    // an ok({...}), so no test has seen what a bare Caddy actually answers.
-    it("caddy_list_servers surfaces the empty-instance failure rather than 'No HTTP servers configured'", async () => {
+    // The first-run empty state, and the reason it needs a LIVE test: a bare
+    // Caddy has no `apps` key, so GET /config/apps/http/servers fails the path
+    // walk with HTTP 400 rather than returning {}. Every mocked fixture feeds
+    // ok({...}), so the whole suite could stay green while this tool answered a
+    // fresh instance with a raw Go error -- which is exactly what it used to do.
+    it("caddy_list_servers reports an empty instance as empty, not as a Go error", async () => {
       const handler = getHandler(registerOperationalTools, "caddy_list_servers");
       const result = await handler({});
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("invalid traversal path");
-      expect(result.content[0].text).not.toContain("No HTTP servers configured");
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0].text).toBe("No HTTP servers configured");
+      expect(result.content[0].text).not.toContain("invalid traversal path");
     });
 
     // An adapter failure has to come back as an error result. If this guard

--- a/src/tests/launcher.test.ts
+++ b/src/tests/launcher.test.ts
@@ -39,10 +39,15 @@ interface RunResult {
  * Run the launcher to completion. `onStderr` can fire a signal once the child
  * announces itself -- signalling before the child is up would test the wrong
  * thing.
+ *
+ * An `undefined` value REMOVES a variable. The child's env starts from
+ * process.env, and Node's spawn skips keys whose value is undefined, so this is
+ * how a case asserts "genuinely unset" instead of inheriting whatever the
+ * machine running the suite happens to export.
  */
 function runLauncher(
   args: string[],
-  env: Record<string, string>,
+  env: Record<string, string | undefined>,
   onStderr?: (chunk: string, child: ReturnType<typeof spawn>) => void,
 ): Promise<RunResult> {
   return new Promise((resolve) => {
@@ -130,6 +135,32 @@ describe.skipIf(!existsSync(DIST_CLI))("launcher: runtime selection", () => {
 });
 
 /**
+ * Answering `--version` is MANDATORY for any stand-in oam.
+ *
+ * Before spawning, the launcher runs a synchronous `execFileSync(oam,
+ * ["--version"])` and requires >= OAM_MIN (0.9.0). A fake that ignores the
+ * probe does not merely fail the gate -- if it blocks, execFileSync blocks the
+ * launcher forever, and if it answers unparseably the launcher silently falls
+ * back to Node, so the test would measure the fallback path while appearing to
+ * exercise the oam one.
+ *
+ * Shared by both POSIX-gated blocks below. The fakes are bash scripts, which is
+ * also why those blocks skip on Windows: Node cannot spawn a .cmd/.bat without
+ * `shell: true`, the same constraint that keeps the launcher's own discovery to
+ * `.exe`.
+ */
+const VERSION_PROBE = ['if [ "$1" = "--version" ]; then echo "oam 0.9.0"; exit 0; fi'];
+
+/** Write an executable stand-in oam into a fresh temp dir; returns its path. */
+function writeFake(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "caddy-mcp-fake-oam-"));
+  const file = join(dir, "oam");
+  writeFileSync(file, body, "utf-8");
+  chmodSync(file, 0o755);
+  return file;
+}
+
+/**
  * Signal forwarding and escalation.
  *
  * POSIX only, deliberately: there are no POSIX signals on Windows, where
@@ -138,18 +169,6 @@ describe.skipIf(!existsSync(DIST_CLI))("launcher: runtime selection", () => {
  * to the whole process group -- behavior this harness cannot drive.
  */
 describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: signal handling", () => {
-  /**
-   * Answering `--version` is MANDATORY for any stand-in oam.
-   *
-   * Before spawning, the launcher runs a synchronous `execFileSync(oam,
-   * ["--version"])` and requires >= OAM_MIN (0.9.0). A fake that ignores the
-   * probe does not merely fail the gate -- if it blocks, execFileSync blocks
-   * the launcher forever, and if it answers unparseably the launcher silently
-   * falls back to Node, so the test would measure the fallback path while
-   * appearing to exercise signal forwarding.
-   */
-  const VERSION_PROBE = ['if [ "$1" = "--version" ]; then echo "oam 0.9.0"; exit 0; fi'];
-
   const GRACEFUL = [
     "#!/bin/bash",
     ...VERSION_PROBE,
@@ -171,14 +190,6 @@ describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: signal handling", () 
 
   /** An oam that satisfies discovery but is older than the launcher's floor. */
   const TOO_OLD = ["#!/bin/bash", 'echo "oam 0.8.9"', "exit 0", ""].join("\n");
-
-  function writeFake(body: string): string {
-    const dir = mkdtempSync(join(tmpdir(), "caddy-mcp-fake-oam-"));
-    const file = join(dir, "oam");
-    writeFileSync(file, body, "utf-8");
-    chmodSync(file, 0o755);
-    return file;
-  }
 
   /** A stand-in oam that either shuts down cleanly on a signal or ignores it. */
   function fakeOam(kind: "graceful" | "wedged"): string {
@@ -235,5 +246,311 @@ describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: signal handling", () 
     const res = await runWithSignals(fakeOam("graceful"), 3);
     expect(res.stderr).toContain("CHILD: cleanup ran");
     expect(res.code).toBe(0);
+  }, 30000);
+});
+
+/**
+ * `CADDY_MCP_SANDBOX=1` grant derivation.
+ *
+ * sandboxFlags() is module-scope inside an executable script, so there is
+ * nothing to import: the seam is the same stand-in oam the block above uses,
+ * told to echo the argv it was handed. That argv IS the contract -- every grant
+ * fails CLOSED, so a wrong one shows up as a connection error or a feature that
+ * quietly does nothing, never as a complaint from the launcher.
+ *
+ * POSIX only for the same reason as the signal block: the fake is a bash script.
+ */
+describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: sandbox grants", () => {
+  /** A stand-in oam that reports the argv it was given, one entry per line. */
+  const ECHO_ARGV = ["#!/bin/bash", ...VERSION_PROBE, 'for a in "$@"; do echo "ARGV: $a" >&2; done', "exit 0", ""].join(
+    "\n",
+  );
+
+  /**
+   * The argv the launcher handed oam, in order.
+   *
+   * CADDY_MCP_RUNTIME=oam so a fake that somehow fails discovery is a loud
+   * failure rather than a silent fallback to Node, which would report no flags
+   * at all and pass every "did not grant X" assertion for the wrong reason.
+   * The two derived variables are cleared first: the suite must not read
+   * differently on a machine that exports its own CADDY_ADMIN_URL.
+   */
+  async function argvFor(env: Record<string, string | undefined>): Promise<string[]> {
+    const res = await runLauncher([], {
+      OAM_BIN: writeFake(ECHO_ARGV),
+      CADDY_MCP_RUNTIME: "oam",
+      CADDY_MCP_SANDBOX: "1",
+      CADDY_ADMIN_URL: undefined,
+      CADDY_MCP_SNAPSHOT_DIR: undefined,
+      ...env,
+    });
+    expect(res.code, res.stderr).toBe(0);
+    return res.stderr
+      .split("\n")
+      .filter((line) => line.startsWith("ARGV: "))
+      .map((line) => line.slice("ARGV: ".length));
+  }
+
+  /** The value of a single `--flag=value` grant, or undefined when absent. */
+  function grant(argv: string[], flag: string): string | undefined {
+    return argv.find((a) => a.startsWith(`${flag}=`))?.slice(flag.length + 1);
+  }
+
+  it("grants the endpoint api.ts actually dials", async () => {
+    const argv = await argvFor({});
+    // src/api.ts declares DEFAULT_URL = "http://localhost:2019". The grant and
+    // the dial are matched as TEXT, so a launcher defaulting to 127.0.0.1 while
+    // the server dials localhost denies every request out of the box -- with
+    // both files reading correctly on their own.
+    expect(grant(argv, "--allow-net")).toBe("localhost");
+    // Process-level flags belong BEFORE the subcommand: `oam run --permission`
+    // is rejected outright.
+    expect(argv.indexOf("--permission")).toBe(0);
+    expect(argv[argv.indexOf("run") + 1]).toBe(DIST_CLI);
+  }, 30000);
+
+  it("derives the grant from CADDY_ADMIN_URL, host only", async () => {
+    const argv = await argvFor({ CADDY_ADMIN_URL: "http://caddy.internal:9000" });
+    // Host WITHOUT the port. oam presents the bare hostname to the net check for
+    // `fetch` and "host:port" only for sockets, and grants are prefix-matched --
+    // "caddy.internal" does not start with "caddy.internal:9000", so pinning the
+    // port denies every request api.ts makes over TCP.
+    expect(grant(argv, "--allow-net")).toBe("caddy.internal");
+  }, 30000);
+
+  for (const [label, value] of [
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ]) {
+    it(`treats an ${label} CADDY_ADMIN_URL as unset, not as "grant everything"`, async () => {
+      const argv = await argvFor({ CADDY_ADMIN_URL: value });
+      expect(grant(argv, "--allow-net")).toBe("localhost");
+      // The regression: `??` keeps "" (only null/undefined fall through), the
+      // URL parse is skipped, and the BARE --allow-net grants every host on the
+      // network -- a sandbox switched on and silently doing nothing. api.ts
+      // reads the same variable with `||`, so "" already means "use the
+      // default" there; the launcher has to agree.
+      expect(argv).not.toContain("--allow-net");
+    }, 30000);
+  }
+
+  for (const [label, value] of [
+    ["URL form", "unix:///var/run/caddy-admin.sock"],
+    ["Caddy network-address form", "unix//var/run/caddy-admin.sock"],
+    // The MALFORMED spellings matter as much as the tidy two, and for a
+    // counter-intuitive reason: each one parses (or throws) into an empty
+    // hostname, so a check matching only the well-formed pair would hand these
+    // the BARE --allow-net -- the widest possible grant, for input that plainly
+    // meant a socket. src/api.ts fails all of them up front in
+    // getMalformedUnixUrl, so denying the net category costs nothing.
+    ["single slash after unix:", "unix:/run/caddy-admin.sock"],
+    ["relative path", "unix://relative.sock"],
+    ["bare scheme", "unix://"],
+    // getUnixSocketPath is case-SENSITIVE and rejects this, but
+    // getMalformedUnixUrl's /^unix[:/]/i accepts it -- so the launcher has to
+    // follow the case-insensitive one or uppercase falls through to wide open.
+    ["uppercase scheme", "UNIX:///var/run/caddy-admin.sock"],
+  ]) {
+    it(`emits NO net grant for a unix-socket CADDY_ADMIN_URL (${label})`, async () => {
+      const argv = await argvFor({ CADDY_ADMIN_URL: value });
+      // The same wide-open shape the empty-string case above guards, reached by
+      // a different route: `new URL("unix:///...").hostname` is "" (and the
+      // Caddy spelling throws outright), so the host check fell through and left
+      // the BARE --allow-net -- every host on the network, handed out for the
+      // MOST hardened admin config Caddy recommends.
+      //
+      // An OMITTED --allow-net is what denies the category (oam reads absent as
+      // false, bare as "*"), so assert absence, not a narrower value.
+      expect(argv.filter((a) => a.startsWith("--allow-net"))).toEqual([]);
+      // The sandbox must still be on -- absence of the flag has to mean "denied",
+      // not "we never got as far as building flags".
+      expect(argv).toContain("--permission");
+    }, 30000);
+  }
+
+  it("does not mistake a TCP host merely starting with 'unix' for a socket", async () => {
+    // The false positive the unix check has to avoid; src/api.ts guards the same
+    // case in getMalformedUnixUrl by matching "unix:" / "unix/" rather than a
+    // bare "unix" prefix.
+    const argv = await argvFor({ CADDY_ADMIN_URL: "http://unix.example.com:2019" });
+    expect(grant(argv, "--allow-net")).toBe("unix.example.com");
+  }, 30000);
+
+  it("grants every environment variable the shipped bundle reads", async () => {
+    const argv = await argvFor({});
+    // Keep in step with `grep -rn process.env src/` outside src/tests.
+    expect(grant(argv, "--allow-env")?.split(",")).toEqual([
+      "CADDY_ADMIN_URL",
+      "CADDY_API_TOKEN",
+      "CADDY_LOAD_TIMEOUT",
+      "CADDY_MAX_RETRIES",
+      "CADDY_MCP_SNAPSHOT_DIR",
+      "CADDY_TIMEOUT",
+    ]);
+    // CADDY_MCP_SNAPSHOT_DIR is the one that was missing. A denied variable is
+    // ABSENT from process.env rather than throwing, so src/snapshots.ts read it
+    // as "not configured": caddy_revert degraded to memory-only and neither
+    // process said anything.
+  }, 30000);
+
+  it("leaves the filesystem denied when snapshot persistence is off", async () => {
+    const argv = await argvFor({});
+    expect(argv.filter((a) => a.startsWith("--allow-fs"))).toEqual([]);
+  }, 30000);
+
+  it("grants exactly the snapshot directory when persistence is on", async () => {
+    // A path, not a real directory: the grant is derived textually and the
+    // launcher never stats it. An absolute path is already normalized, so the
+    // two spellings collapse to one entry (see the relative case below).
+    const dir = join(tmpdir(), "caddy-mcp-snapshots");
+    const argv = await argvFor({ CADDY_MCP_SNAPSHOT_DIR: dir });
+    // Read AND write: snapshots.ts writes each snapshot and reads the directory
+    // back to rehydrate the ring on the next start. Granting the variable
+    // without the directory only moves the silent failure -- persist() swallows
+    // its own I/O errors and falls back to the in-memory ring.
+    expect(grant(argv, "--allow-fs-read")).toBe(dir);
+    expect(grant(argv, "--allow-fs-write")).toBe(dir);
+  }, 30000);
+
+  it("grants both spellings of a relative snapshot directory", async () => {
+    // Grants are plain string PREFIXES matched against the path each call
+    // passes. snapshots.ts hands the raw variable to readdirSync/mkdirSync but
+    // builds per-file paths with path.join, which normalizes "./snaps" to
+    // "snaps" -- so the raw form alone misses the files and the normalized form
+    // alone misses the directory listing.
+    const argv = await argvFor({ CADDY_MCP_SNAPSHOT_DIR: "./snaps" });
+    expect(grant(argv, "--allow-fs-read")).toBe("./snaps,snaps");
+    expect(grant(argv, "--allow-fs-write")).toBe("./snaps,snaps");
+  }, 30000);
+
+  it("emits no permission flags at all unless CADDY_MCP_SANDBOX=1", async () => {
+    const argv = await argvFor({ CADDY_MCP_SANDBOX: undefined });
+    expect(argv[0]).toBe("run");
+    expect(argv.some((a) => a === "--permission" || a.startsWith("--allow-"))).toBe(false);
+  }, 30000);
+});
+
+/**
+ * The version gate's TWO causes, and the AUTO half of both.
+ *
+ * An unparseable `--version` and an old one land in the SAME branch, but the
+ * launcher deliberately splits their detail and their remedy: a null version is
+ * not "old", and the branch's own comment warns that telling that user to `oam
+ * self-update` "sends them after the one cause it definitely is not". Only the
+ * too-old + CADDY_MCP_RUNTIME=oam corner was pinned, which left the header's
+ * promise -- "An older oam is not an error: the launcher falls back to Node and
+ * says so on stderr" -- with no test at all.
+ *
+ * POSIX only for the same reason as the blocks above: the fakes are bash scripts.
+ */
+describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: version gate fallback", () => {
+  /** An oam that satisfies discovery but is older than the launcher's floor. */
+  const TOO_OLD = ["#!/bin/bash", 'echo "oam 0.8.9"', "exit 0", ""].join("\n");
+
+  /**
+   * An oam that runs cleanly and answers with something the launcher's
+   * `(\d+)\.(\d+)\.(\d+)` cannot read, so oamVersion returns null. Stands in for
+   * the causes a test cannot construct portably -- wrong arch, a non-oam binary
+   * on OAM_BIN, a file deleted between the stat and the probe.
+   */
+  const UNREADABLE = ["#!/bin/bash", 'echo "not a version"', "exit 0", ""].join("\n");
+
+  it("falls back to Node when the discovered oam is too old", async () => {
+    // CADDY_MCP_RUNTIME REMOVED, not set to "auto": auto is the default and the
+    // mode every install actually runs in, so the documented fallback has to
+    // hold without the variable being present at all.
+    const res = await runLauncher(["--version"], {
+      CADDY_MCP_RUNTIME: undefined,
+      OAM_BIN: writeFake(TOO_OLD),
+    });
+    expect(res.code, res.stderr).toBe(0);
+    // Exit 0 alone would also pass on a launcher that started nothing. The
+    // version on stdout is what proves the Node fallback actually SERVED.
+    expect(res.stdout.trim()).toMatch(/^caddy-mcp \d+\.\d+\.\d+/);
+    // Naming the version found is the point of the notice: a silent downgrade is
+    // how someone keeps running an oam they meant to update.
+    expect(res.stderr).toContain("0.8.9");
+    expect(res.stderr).toContain("older than 0.9.0");
+    expect(res.stderr).toContain("using Node instead");
+  }, 30000);
+
+  it("falls back to Node when oam does not report a readable version", async () => {
+    const res = await runLauncher(["--version"], {
+      CADDY_MCP_RUNTIME: "auto",
+      OAM_BIN: writeFake(UNREADABLE),
+    });
+    expect(res.code, res.stderr).toBe(0);
+    expect(res.stdout.trim()).toMatch(/^caddy-mcp \d+\.\d+\.\d+/);
+    // The other half of the split: this diagnostic must NOT claim a version it
+    // never read, because "older than 0.9.0" would send the operator to
+    // self-update a binary that never ran.
+    expect(res.stderr).toContain("could not be run, or did not report a version");
+    expect(res.stderr).toContain("using Node instead");
+    expect(res.stderr).not.toContain("self-update");
+  }, 30000);
+
+  it("names the unreadable-binary remedy, not self-update, under CADDY_MCP_RUNTIME=oam", async () => {
+    // The loud counterpart of the case above, and where the two remedies are
+    // actually printed -- auto says only "using Node instead".
+    const res = await runLauncher(["--version"], {
+      CADDY_MCP_RUNTIME: "oam",
+      OAM_BIN: writeFake(UNREADABLE),
+    });
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain("could not be run, or did not report a version this launcher understands");
+    expect(res.stderr).toContain("Check that it is an executable oam binary");
+    // The regression that would matter: `oam self-update` cannot fix a binary
+    // that never ran, so offering it costs the operator the real cause.
+    expect(res.stderr).not.toContain("self-update");
+  }, 30000);
+});
+
+/**
+ * Spawn failure AFTER a passing version probe.
+ *
+ * The window the launcher's own comment names: discovery is stat-only and the
+ * probe is a separate process, so an oam can satisfy both and still be
+ * unexecutable a moment later. spawn reports that asynchronously via 'error',
+ * never as a throw, and auto mode has to degrade to Node -- an escaping 'error'
+ * would take the server down for every host whose oam went missing.
+ *
+ * The fake DELETES ITSELF during the probe, which is one of the causes that
+ * comment lists. Deletion rather than chmod because a running bash holds its own
+ * open fd (so the script finishes normally) while the launcher's next use of that
+ * path fails with ENOENT, and unlink behaves the same on every filesystem the
+ * suite might run on -- the exec bit does not.
+ *
+ * POSIX only, like the blocks above: the fake is a bash script.
+ */
+describe.skipIf(isWin || !existsSync(DIST_CLI))("launcher: spawn failure fallback", () => {
+  /**
+   * Answers `--version` with a supported version, then vanishes. The "CHILD: up"
+   * line is never reached: it exists so a spawn that unexpectedly SUCCEEDS is
+   * visible as a failed assertion rather than passing for the wrong reason.
+   */
+  const VANISHING = ["#!/bin/bash", 'rm -f "$0"', ...VERSION_PROBE, 'echo "CHILD: up" >&2', "exit 0", ""].join("\n");
+
+  it("falls back to Node when a version-passing oam cannot be spawned", async () => {
+    const res = await runLauncher(["--version"], {
+      CADDY_MCP_RUNTIME: "auto",
+      OAM_BIN: writeFake(VANISHING),
+    });
+    expect(res.code, res.stderr).toBe(0);
+    expect(res.stdout.trim()).toMatch(/^caddy-mcp \d+\.\d+\.\d+/);
+    // Proves the version came from the in-process fallback rather than from an
+    // oam that turned out to be runnable after all.
+    expect(res.stderr).not.toContain("CHILD: up");
+  }, 30000);
+
+  it("fails loudly on an unspawnable oam under CADDY_MCP_RUNTIME=oam", async () => {
+    // Same failure, opposite contract: explicitly demanding oam must not quietly
+    // run a different runtime than the operator asked for.
+    const res = await runLauncher(["--version"], {
+      CADDY_MCP_RUNTIME: "oam",
+      OAM_BIN: writeFake(VANISHING),
+    });
+    expect(res.code).toBe(1);
+    expect(res.stderr).toContain("failed to launch oam");
+    expect(res.stdout).toBe("");
   }, 30000);
 });

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -400,6 +400,20 @@ describe("caddy-mcp tools", () => {
         idempotentHint: false,
       });
     });
+
+    it("caddy_config_delete agrees with caddy_remove_route about idempotency", async () => {
+      // The two tools issue a BYTE-IDENTICAL request for the same job:
+      // caddy_remove_route's index mode calls configDelete on
+      // "apps/http/servers/<srv>/routes/<i>", which is exactly what
+      // caddy_config_delete sends when handed that path -- and that path is this
+      // tool's OWN documented example. Advertising the lower-level sibling as
+      // idempotent while the higher-level one says otherwise would let a host
+      // retry through the door that is still marked safe.
+      expect(await getAnnotations("caddy_config_delete")).toMatchObject({
+        destructiveHint: true,
+        idempotentHint: false,
+      });
+    });
   });
 
   describe("caddy_config_set default mode", () => {

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -335,6 +335,73 @@ describe("caddy-mcp tools", () => {
     });
   });
 
+  describe("caddy_reverse_proxy `to` bounds", () => {
+    async function getReverseProxySchema() {
+      const calls: any[] = [];
+      const mockServer = {
+        tool: vi.fn((...args: any[]) => calls.push(args)),
+        resource: vi.fn(),
+      };
+      const { registerRouteTools } = await import("../tools/routes.js");
+      registerRouteTools(mockServer as any);
+      return calls.find((c) => c[0] === "caddy_reverse_proxy")?.[2];
+    }
+
+    it("accepts a non-empty list of non-empty upstreams", async () => {
+      const schema = await getReverseProxySchema();
+      expect(() => schema.to.parse(["localhost:3000"])).not.toThrow();
+      expect(() => schema.to.parse(["https://backend.example.com", "https://b.example.com:9443"])).not.toThrow();
+    });
+
+    it("rejects an empty list and empty entries at the schema boundary", async () => {
+      const schema = await getReverseProxySchema();
+      // A reverse_proxy with no upstreams (or a "" upstream) is a route that
+      // 502s every request. The handler refuses these too -- see the runtime
+      // guards in handlers.test.ts -- but rejecting here means a real MCP call
+      // never reaches the handler with them.
+      expect(() => schema.to.parse([])).toThrow();
+      expect(() => schema.to.parse([""])).toThrow();
+      expect(() => schema.to.parse(["localhost:3000", ""])).toThrow();
+    });
+  });
+
+  describe("destructive/idempotent annotations", () => {
+    async function getAnnotations(toolName: string) {
+      const calls: any[] = [];
+      const mockServer = {
+        tool: vi.fn((...args: any[]) => calls.push(args)),
+        resource: vi.fn(),
+      };
+      const { registerConfigTools } = await import("../tools/config.js");
+      const { registerRouteTools } = await import("../tools/routes.js");
+      registerConfigTools(mockServer as any);
+      registerRouteTools(mockServer as any);
+      return calls.find((c) => c[0] === toolName)?.[3];
+    }
+
+    // Both hints describe the TOOL, and a host gates on them before it can see
+    // which action or targeting mode a given call carries -- so the worst case
+    // reachable through the tool is what has to be advertised.
+    it("caddy_config_by_id advertises its delete action as destructive", async () => {
+      // action='delete' removes the identified object and every descendant,
+      // exactly like caddy_config_delete; action='set' with mode='append' is a
+      // POST, so a repeat appends a second copy.
+      expect(await getAnnotations("caddy_config_by_id")).toMatchObject({
+        destructiveHint: true,
+        idempotentHint: false,
+      });
+    });
+
+    it("caddy_remove_route advertises the weaker of its two targeting modes", async () => {
+      // @id removal is idempotent; index removal is not -- Caddy re-packs the
+      // routes array, so index 2 twice removes two different routes.
+      expect(await getAnnotations("caddy_remove_route")).toMatchObject({
+        destructiveHint: true,
+        idempotentHint: false,
+      });
+    });
+  });
+
   describe("caddy_config_set default mode", () => {
     it("defaults to overwrite (PATCH), not append", async () => {
       const calls: any[] = [];

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -195,13 +195,24 @@ export function registerConfigTools(server: McpServer) {
       const current = await api.configGet();
       const res = await api.loadConfig(snap.config, "application/json");
       if (!res.ok) return formatResult(res);
-      if (current.ok && isSnapshotableConfig(current.data)) {
+      const capturedRollforward = current.ok && isSnapshotableConfig(current.data);
+      if (capturedRollforward) {
         saveSnapshot(current.data, "caddy_revert");
       }
       const when = new Date(snap.timestamp).toISOString();
+      // Say so when the safety net was skipped. The load is what decides success,
+      // so a failed pre-revert read does NOT make this a failed revert -- but it
+      // does mean the config that was just replaced went unrecorded and this revert
+      // cannot itself be reverted. Reporting a bare success would hide that at
+      // exactly the moment it matters, and the read fails for an ordinary reason:
+      // Caddy restarts its admin listener on every /load, so a revert issued during
+      // that window loses the roll-forward snapshot while everything else succeeds.
+      const note = capturedRollforward
+        ? ""
+        : " Warning: the pre-revert config could not be read, so no roll-forward snapshot was captured -- this revert cannot be undone with caddy_revert.";
       return {
         content: [
-          { type: "text" as const, text: `Reverted to snapshot [${index}] (${when}, trigger=${snap.trigger}).` },
+          { type: "text" as const, text: `Reverted to snapshot [${index}] (${when}, trigger=${snap.trigger}).${note}` },
         ],
       };
     },
@@ -231,7 +242,13 @@ export function registerConfigTools(server: McpServer) {
         .default(false)
         .describe("Must be true to actually delete (only enforced for action='delete')"),
     },
-    { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    // destructiveHint is keyed to the worst thing this tool can do, not the
+    // default action: action='delete' removes the identified object and every
+    // descendant, exactly like caddy_config_delete. Hosts gate on the hint
+    // before they can see which action the call carries.
+    // idempotentHint stays false for the same reason -- action='set' with
+    // mode='append' is a POST, so a repeated call appends a second copy.
+    { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
     async ({ id, action, value, subpath, mode, confirm }) => {
       if (action === "get") {
         return formatResult(await api.configByIdGet(id, subpath));
@@ -261,7 +278,14 @@ export function registerConfigTools(server: McpServer) {
         }
         return formatResult(await api.configByIdDelete(id, subpath));
       }
-      return { isError: true, content: [{ type: "text" as const, text: `Unknown action: ${action}` }] };
+      // Not live error handling: the three branches above cover every member of
+      // the `action` enum, so `action` is `never` here. The assignment is the
+      // exhaustiveness check -- adding a fourth action to the enum without a
+      // branch for it fails to compile on this line rather than silently
+      // falling through. The return only exists because TypeScript requires a
+      // terminal one.
+      const unhandled: never = action;
+      return { isError: true, content: [{ type: "text" as const, text: `Unknown action: ${String(unhandled)}` }] };
     },
   );
 }

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -50,7 +50,15 @@ export function registerConfigTools(server: McpServer) {
         .default(false)
         .describe("Must be true to actually delete the config node (safety)"),
     },
-    { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+    // idempotentHint is FALSE because the hint covers the whole tool and cannot see
+    // the path it is called with. This tool's own documented example ends in an
+    // array index -- 'apps/http/servers/srv0/routes/0' -- and Caddy re-packs an
+    // array after a delete, so repeating that call removes a DIFFERENT route each
+    // time. caddy_remove_route carries the same correction for the byte-identical
+    // underlying request; the two must agree. Nothing here is auto-recoverable
+    // either: only caddy_load captures a snapshot, so a spurious repeat cannot be
+    // undone with caddy_revert.
+    { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
     async ({ path, confirm }) => {
       if (!confirm) {
         return {

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -201,15 +201,26 @@ export function registerConfigTools(server: McpServer) {
       }
       const when = new Date(snap.timestamp).toISOString();
       // Say so when the safety net was skipped. The load is what decides success,
-      // so a failed pre-revert read does NOT make this a failed revert -- but it
-      // does mean the config that was just replaced went unrecorded and this revert
-      // cannot itself be reverted. Reporting a bare success would hide that at
-      // exactly the moment it matters, and the read fails for an ordinary reason:
-      // Caddy restarts its admin listener on every /load, so a revert issued during
-      // that window loses the roll-forward snapshot while everything else succeeds.
+      // so a skipped snapshot does NOT make this a failed revert -- but it does mean
+      // the config just replaced went unrecorded, and reporting a bare success would
+      // hide that at exactly the moment it matters.
+      //
+      // TWO distinct reasons reach here, and `current.ok` separates them, so the
+      // message must not collapse them into one. A read that returned HTTP 200 with
+      // a body that simply is not a JSON object (Caddy answers a config-less
+      // instance with a literal `null`) is not a read FAILURE, and saying so would
+      // send the operator after a connectivity or admin-listener problem that does
+      // not exist. The save path above already draws exactly this distinction.
+      // Naming a cause the signal does not support is what got 1.2.5 deprecated.
+      const skipped = current.ok
+        ? "the pre-revert config was empty or not a JSON object"
+        : "the pre-revert config could not be read";
+      // "cannot be rolled back to what it replaced", not "cannot be undone": other
+      // snapshots may still sit in the ring, so the operator is not out of options
+      // -- what is gone is specifically the state this revert overwrote.
       const note = capturedRollforward
         ? ""
-        : " Warning: the pre-revert config could not be read, so no roll-forward snapshot was captured -- this revert cannot be undone with caddy_revert.";
+        : ` Warning: ${skipped}, so no roll-forward snapshot was captured -- this revert cannot be rolled back to the config it replaced.`;
       return {
         content: [
           { type: "text" as const, text: `Reverted to snapshot [${index}] (${when}, trigger=${snap.trigger}).${note}` },

--- a/src/tools/operational.ts
+++ b/src/tools/operational.ts
@@ -49,7 +49,12 @@ function describeServer(rawValue: unknown): string {
       : {};
   const listen: unknown[] = Array.isArray(raw.listen) ? raw.listen : [];
   const routes: unknown[] = Array.isArray(raw.routes) ? raw.routes : [];
-  const hasExplicitTls = !!raw.tls_connection_policies;
+  // An empty tls_connection_policies array configures nothing, so it must read the same
+  // as an absent key: fall through to the listen-port heuristic rather than claim
+  // "enabled". A present-but-non-array value is a malformed config we can't interpret --
+  // keep the old "something is there" reading for it rather than silently calling it off.
+  const tlsPolicies = raw.tls_connection_policies;
+  const hasExplicitTls = Array.isArray(tlsPolicies) ? tlsPolicies.length > 0 : !!tlsPolicies;
   const listensHttps = listen.some((l) => typeof l === "string" && HTTPS_PORT_RE.test(l));
   const tls = hasExplicitTls ? "enabled" : listensHttps ? "auto (HTTPS)" : "off (HTTP only)";
   const listenStr = listen.length > 0 ? listen.map(String).join(", ") : "default";

--- a/src/tools/operational.ts
+++ b/src/tools/operational.ts
@@ -187,6 +187,19 @@ export function registerOperationalTools(server: McpServer) {
     { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     async () => {
       const res = await api.configGet<Record<string, CaddyServerSummary>>("apps/http/servers");
+      // A config-less Caddy has no `apps` key at all, so this read fails the path
+      // walk rather than returning an empty object: 2.11.4 answers HTTP 400
+      // {"error":"invalid traversal path at: config/apps/http"}. Surfacing that raw
+      // made the tool whose entire job is "tell me what servers exist" answer a
+      // fresh instance with a Go internal error instead of the obvious truth.
+      //
+      // The path is a fixed literal, so every way this walk can fail -- missing
+      // apps, http, or servers -- means the same thing and only that thing: no HTTP
+      // servers are configured. That makes the friendly answer honest here rather
+      // than a guess. caddy_status already reports it this way for the same state.
+      if (api.isMissingConfigPath(res)) {
+        return { content: [{ type: "text" as const, text: "No HTTP servers configured" }] };
+      }
       if (!res.ok) return formatResult(res);
 
       const servers = res.data ?? {};

--- a/src/tools/routes.ts
+++ b/src/tools/routes.ts
@@ -74,7 +74,10 @@ const ROUTES_SUMMARY_MAX = 500;
  */
 function serializeRoutesCapped(routes: unknown[]): { json: string; shown: number } {
   const parts: string[] = [];
-  let used = 2; // the enclosing "[" and "]"
+  // Fixed overhead of the wrapper: the opening "[", the "\n" that precedes the
+  // closing bracket, and the "]" itself. The "\n" AFTER the "[" is charged to
+  // the first entry below (as its cost of 1), so it is not counted here.
+  let used = 3;
   for (const route of routes) {
     const entry = JSON.stringify(route, null, 2)
       .split("\n")
@@ -166,6 +169,90 @@ function cleanUpstreamAddr(addr: string): string {
 }
 
 /**
+ * Append `port` to an upstream dial address that carries none.
+ *
+ * A Caddy `dial` is a socket address, not a URL: it has no scheme left to
+ * imply a port once cleanUpstreamAddr has stripped one. Writing the bare host
+ * for "https://backend.example.com" would therefore aim the connection at
+ * whatever a portless dial resolves to rather than at 443, so make the port
+ * the caller meant explicit instead of inheriting a default.
+ *
+ * stripPort() doubles as the port DETECTOR here: it returns its input
+ * unchanged exactly when there is nothing it recognizes as a port to strip
+ * (including the bare-IPv6 case documented on it). That bare-IPv6 form has to
+ * be bracketed before a port can be appended -- "::1:443" reads as another
+ * address group, not as host + port.
+ */
+function withDefaultPort(dial: string, port: number): string {
+  if (stripPort(dial) !== dial) return dial;
+  const bareIpv6 = !dial.startsWith("[") && dial.indexOf(":") !== dial.lastIndexOf(":");
+  return bareIpv6 ? `[${dial}]:${port}` : `${dial}:${port}`;
+}
+
+interface UpstreamPlan {
+  /** Dial addresses, scheme stripped and (for TLS upstreams) port-normalized. */
+  dials: string[];
+  /** True when the handler must carry a TLS transport to reach these upstreams. */
+  tls: boolean;
+}
+
+/**
+ * Resolve the `to` list into dial addresses plus whether the reverse_proxy
+ * handler needs a TLS transport.
+ *
+ * The scheme is load-bearing, not decoration. Caddy dials an upstream in the
+ * clear unless the HANDLER also carries `transport: { protocol: "http",
+ * tls: {} }`, so quietly reducing "https://backend" to `{ dial: "backend" }`
+ * is a security downgrade the caller never sees. An https upstream therefore
+ * emits the transport and pins :443 rather than having its scheme normalized
+ * away.
+ *
+ * A list mixing http and https upstreams is REFUSED rather than resolved:
+ * `transport` is a property of the whole handler, not of an individual
+ * upstream, so either choice would silently apply one entry's scheme to the
+ * other's connection. Splitting them into two routes -- or hand-writing the
+ * handler with caddy_add_route -- keeps that decision with the caller.
+ */
+function planUpstreams(to: string[]): UpstreamPlan | { error: string } {
+  if (to.length === 0) {
+    return { error: `"to" must list at least one upstream address (e.g. ["localhost:3000"]).` };
+  }
+  const dials: string[] = [];
+  let secure = 0;
+  let plain = 0;
+  for (const raw of to) {
+    // Trim for the same reason `from` is trimmed: surrounding whitespace would
+    // otherwise become part of the dial address.
+    const trimmed = raw.trim();
+    // Case-sensitive, matching cleanUpstreamAddr's strip -- a scheme this test
+    // recognizes must be one the strip also removes, or the "scheme" would
+    // survive into the dial address.
+    const isTls = trimmed.startsWith("https://");
+    const dial = cleanUpstreamAddr(trimmed);
+    if (dial.length === 0) {
+      return {
+        error:
+          `upstream ${JSON.stringify(raw)} has no address to dial. Each "to" entry needs a host ` +
+          `and port (e.g. "localhost:3000", "https://backend.example.com:8443").`,
+      };
+    }
+    if (isTls) secure++;
+    else plain++;
+    dials.push(isTls ? withDefaultPort(dial, 443) : dial);
+  }
+  if (secure > 0 && plain > 0) {
+    return {
+      error:
+        `"to" mixes https:// and non-https upstreams. Caddy's TLS transport applies to the whole ` +
+        `reverse_proxy handler, not per-upstream, so one scheme would be silently forced on the ` +
+        `other's connection. Split them into two routes, or build the handler explicitly with ` +
+        `caddy_add_route.`,
+    };
+  }
+  return { dials, tls: secure > 0 };
+}
+
+/**
  * Detect Caddy's "parent path does not exist" failure mode for a config write.
  *
  * Caddy returns this when writing to a path whose parent (e.g.
@@ -226,6 +313,39 @@ function serverNotFoundError(srv: string, op = "operation") {
   };
 }
 
+/**
+ * A read of `apps/http/servers/<srv>` that came back as a JSON `null`.
+ *
+ * Deliberately NOT serverNotFoundError, and deliberately not worded as "does not
+ * exist". Caddy answers an UNKNOWN server with HTTP 200 and a body of literal
+ * `null` -- not a 404 -- and it answers a server whose config IS null with byte
+ * identical output. Verified against Caddy 2.11.4:
+ *   GET /config/apps/http/servers/typo    -> 200 null   (no such key)
+ *   GET /config/apps/http/servers/nulled  -> 200 null   (key present, value null)
+ * Nothing downstream can separate the two, so this names both causes rather than
+ * picking one. Asserting the likelier cause here is the mistake that shipped in
+ * 1.2.5 and had to be deprecated: a confident message pointing at the wrong thing
+ * is worse than an honest ambiguous one.
+ *
+ * An empty OBJECT is a different answer and must not land here -- `{}` is a real,
+ * routeless server, which the summary path renders as "no routes configured".
+ */
+function serverNullError(srv: string) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text" as const,
+        text:
+          `Error: Server "${srv}" is not configured, or its config is null -- Caddy returns the same ` +
+          `response (HTTP 200 with a body of null) for both, so they cannot be told apart from here. ` +
+          `Use caddy_list_servers to see which servers exist, or create this one with caddy_load or ` +
+          `caddy_config_set at path 'apps/http/servers/${srv}' with at minimum: { "listen": [":443"] }`,
+      },
+    ],
+  };
+}
+
 export function registerRouteTools(server: McpServer) {
   server.tool(
     "caddy_reverse_proxy",
@@ -233,13 +353,19 @@ export function registerRouteTools(server: McpServer) {
       "When `id` is OMITTED the route is appended to the server's routes array — calling the tool twice with the same args produces TWO duplicate routes (non-idempotent). " +
       "When `id` is SUPPLIED the route is written via PATCH under that @id, so repeat calls REPLACE in place (idempotent). " +
       "Strongly recommended: supply a stable `id` for any route managed from automation or production tooling. " +
-      "Note: @ids are config-global in Caddy (NOT route-scoped). If `id` collides with an @id used by a non-route object (TLS issuer, server, etc.) the call refuses with an error rather than clobbering it. Once an @id is registered to a route under one server, subsequent calls update that route in place regardless of the `server` argument.",
+      "Note: @ids are config-global in Caddy (NOT route-scoped). If `id` collides with an @id used by a non-route object (TLS issuer, server, etc.) the call refuses with an error rather than clobbering it. Once an @id is registered to a route under one server, subsequent calls update that route in place regardless of the `server` argument. " +
+      "Upstream scheme is honored: an `https://` upstream gets a TLS transport and defaults to port 443, anything else is dialed in the clear. A `to` list that MIXES https:// and non-https entries is refused — the TLS transport applies to the whole handler, not per-upstream — so split those into two routes or use caddy_add_route.",
     {
       from: z
         .string()
         .min(1)
         .describe("Domain, path, or domain/path to match (e.g., 'api.local', '/api/*', 'app.local/ws')"),
-      to: z.array(z.string()).describe("Upstream addresses (e.g., ['localhost:3000', 'localhost:3001'])"),
+      to: z
+        .array(z.string().min(1))
+        .min(1)
+        .describe(
+          "Upstream addresses, at least one (e.g., ['localhost:3000', 'localhost:3001']). An 'https://' prefix dials the upstream over TLS (port 443 unless one is given); http:// and bare addresses are dialed in the clear. Do not mix https:// and non-https entries in one call.",
+        ),
       server: z
         .string()
         .regex(/^[\w-]{1,128}$/)
@@ -275,15 +401,27 @@ export function registerRouteTools(server: McpServer) {
           ],
         };
       }
-      const cleanedTo = to.map(cleanUpstreamAddr);
+      const plan = planUpstreams(to);
+      if ("error" in plan) {
+        return {
+          isError: true,
+          content: [{ type: "text" as const, text: `Error: ${plan.error}` }],
+        };
+      }
+      const cleanedTo = plan.dials;
+      const proxyHandler: Record<string, unknown> = {
+        handler: "reverse_proxy",
+        upstreams: cleanedTo.map((addr) => ({ dial: addr })),
+      };
+      // Only set on the TLS path so a plain-http route keeps the exact handler
+      // shape it has always had -- `transport` present-but-empty is not the
+      // same config as `transport` absent.
+      if (plan.tls) {
+        proxyHandler.transport = { protocol: "http", tls: {} };
+      }
       const route: Record<string, unknown> = {
         match: [match],
-        handle: [
-          {
-            handler: "reverse_proxy",
-            upstreams: cleanedTo.map((addr) => ({ dial: addr })),
-          },
-        ],
+        handle: [proxyHandler],
         terminal: true,
       };
       if (id) {
@@ -424,6 +562,18 @@ export function registerRouteTools(server: McpServer) {
     async ({ server: srv }) => {
       const serverRes = await api.configGet<CaddyServerConfig>(`apps/http/servers/${srv}`);
       if (!serverRes.ok) return formatResult(serverRes);
+
+      // A `null` body is a 200, so the guard above never catches it. Without this
+      // check the `|| {}` below collapses null into an empty config and an unknown
+      // server renders as `Server "typo" (listen: default) -- no routes configured`
+      // with no isError flag: the operator is told a server they believe is live
+      // has no routes, which invites them to overwrite it. `undefined` (an empty
+      // response body) is folded in here too -- it carries no more information than
+      // null does. Anything else, INCLUDING `{}`, is a real server and falls
+      // through: `{}` is a legitimately routeless server, not a missing one.
+      if (serverRes.data === null || serverRes.data === undefined) {
+        return serverNullError(srv);
+      }
 
       const serverConfig = serverRes.data || {};
       const routes: unknown[] = Array.isArray(serverConfig.routes) ? serverConfig.routes : [];
@@ -581,7 +731,9 @@ export function registerRouteTools(server: McpServer) {
 
   server.tool(
     "caddy_remove_route",
-    "Remove a route. Target by @id (preferred — stable across reorderings) or by array index on a specific server. Index-based removal is a two-step read-then-delete and can race against concurrent edits; prefer @id when possible.",
+    "Remove a route. Target by @id (preferred — stable across reorderings) or by array index on a specific server. Index-based removal is a two-step read-then-delete and can race against concurrent edits; prefer @id when possible. " +
+      "Only the @id mode is idempotent: a repeat call cannot remove a different route, it just reports the id as gone. The index mode is NOT — Caddy re-packs the routes array after a removal, so calling with index 2 twice removes TWO DIFFERENT routes. " +
+      "@ids are config-global in Caddy (NOT route-scoped): if `id` resolves to a non-route object (TLS issuer, server, etc.) the call refuses rather than deleting it.",
     {
       id: z
         .string()
@@ -602,7 +754,12 @@ export function registerRouteTools(server: McpServer) {
         .describe("Caddy server name when using index (default: srv0). Ignored when id is provided."),
       confirm: z.boolean().optional().default(false).describe("Must be true to actually remove the route (safety)"),
     },
-    { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+    // idempotentHint is false because the hint covers the TOOL, and hosts gate
+    // on it before they can see which targeting mode a given call carries. The
+    // @id path is idempotent; the index path is not -- Caddy re-packs the
+    // routes array on removal, so a repeated index deletes a different route
+    // each time. The weaker of the two has to win.
+    { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
     async ({ id, index, server: srv, confirm }) => {
       if (!id && index === undefined) {
         return {
@@ -623,6 +780,35 @@ export function registerRouteTools(server: McpServer) {
         };
       }
       if (id) {
+        // GET before DELETE, mirroring caddy_reverse_proxy's guard on the write
+        // path. @ids are config-global in Caddy, not route-scoped, so
+        // DELETE /id/<id> will happily remove a TLS issuer, a server block, or
+        // a nested handler that happens to share the id -- and a delete, unlike
+        // a botched write, has nothing left to inspect afterwards.
+        const existing = await api.configByIdGet(id);
+        // Keep the two failure modes distinct: an @id that does not resolve AT
+        // ALL is a different problem from one that resolves to the wrong kind
+        // of object, and only the caller can tell which one they meant. Surface
+        // the API response verbatim rather than translating it into the
+        // wrong-shape refusal below.
+        if (!existing.ok) return formatResult(existing);
+        if (!isRouteShape(existing.data)) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  `Error: @id "${id}" resolves to a non-route config object ` +
+                  `(no top-level "handle" array). @ids are config-global in Caddy, not ` +
+                  `route-scoped -- refusing to delete it as a route. Inspect it with ` +
+                  `caddy_config_by_id { id: "${id}", action: "get" }, and if you did mean to ` +
+                  `remove that object, delete it deliberately with ` +
+                  `caddy_config_by_id { id: "${id}", action: "delete", confirm: true }.`,
+              },
+            ],
+          };
+        }
         const res = await api.configByIdDelete(id);
         if (res.ok) return { content: [{ type: "text" as const, text: `Route @id="${id}" removed.` }] };
         return formatResult(res);

--- a/src/tools/routes.ts
+++ b/src/tools/routes.ts
@@ -264,6 +264,14 @@ function planUpstreams(to: string[]): UpstreamPlan | { error: string } {
 function isParentMissing(res: { ok: boolean; status: number; error?: string }): boolean {
   if (res.ok) return false;
   if (res.status === 404) return true;
+  // Both markers, because Caddy uses different ones depending on WHERE the path
+  // breaks. Writing under a server that does not exist is the case this helper
+  // exists for, and 2.11.4 answers it with 500 "invalid traversal path at:
+  // config/apps/http/servers/<srv>/routes" -- no 404, and no "key does not exist".
+  // Matching only the older marker made this return false for its own headline
+  // case, so serverNotFoundError was unreachable from all three call sites and
+  // callers got the raw Go error instead of the create-it recipe.
+  if (api.isMissingConfigPath(res)) return true;
   return res.error?.includes("key does not exist") ?? false;
 }
 
@@ -307,7 +315,14 @@ function serverNotFoundError(srv: string, op = "operation") {
     content: [
       {
         type: "text" as const,
-        text: `Error: Server "${srv}" does not exist (${op}). Use caddy_list_servers to see available servers, or create one with caddy_load or caddy_config_set at path 'apps/http/servers/${srv}' with at minimum: { "listen": [":443"] }`,
+        text:
+          `Error: Server "${srv}" does not exist (${op}). Use caddy_list_servers to see what is configured. ` +
+          `To create it: caddy_config_set { path: "apps/http/servers/${srv}", mode: "append", ` +
+          `value: { "listen": [":443"], "routes": [] } }. Both arguments are load-bearing: mode "append" ` +
+          `creates the key, while the default "overwrite" fails with "key does not exist"; and "routes": [] ` +
+          `must be present, or adding the first route fails, because a POST creates a missing routes key as ` +
+          `an object rather than an array. On an instance with no config at all, use caddy_load instead -- ` +
+          `caddy_config_set cannot create the apps/http tree it would write into.`,
       },
     ],
   };
@@ -561,6 +576,15 @@ export function registerRouteTools(server: McpServer) {
     { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     async ({ server: srv }) => {
       const serverRes = await api.configGet<CaddyServerConfig>(`apps/http/servers/${srv}`);
+      // A traversal failure means a segment ABOVE the server name is missing --
+      // apps, http, or servers -- so on a config-less instance this tool used to
+      // answer with a raw `{"error":"invalid traversal path at: config/apps/http"}`,
+      // which tells a first-time operator nothing about what to do next.
+      //
+      // Unlike the null body handled below, this one is NOT ambiguous: if the
+      // parent chain does not exist then neither does the server, so asserting
+      // non-existence here is honest, and serverNotFoundError carries the recipe.
+      if (api.isMissingConfigPath(serverRes)) return serverNotFoundError(srv, "caddy_list_routes");
       if (!serverRes.ok) return formatResult(serverRes);
 
       // A `null` body is a 200, so the guard above never catches it. Without this

--- a/src/tools/tls.ts
+++ b/src/tools/tls.ts
@@ -101,6 +101,41 @@ function validateIssuerShape(tls: Record<string, unknown>): string | null {
   return null;
 }
 
+/** The issuer module that `email` / `ca` / `profile` actually belong to. */
+const ACME_ISSUER_MODULE = "acme";
+
+/**
+ * Confirm policies[0].issuers[0] is an ACME issuer before merging ACME fields into it.
+ * Returns null when it is, or a message naming the module actually found.
+ *
+ * Structure is not enough: `{ "module": "internal" }` (Caddy's local CA) passes
+ * validateIssuerShape and is an entirely ordinary config, yet carries none of these
+ * fields. Writing `email` or `profile` onto it produces a config Caddy rejects on
+ * load, and `ca` is worse -- `internal` has its own `ca` key naming a PKI CA id
+ * ("local"), so set_acme_ca would silently repoint it at an ACME directory URL.
+ *
+ * Only the merge path needs this guard. The PATCH-first path in setIssuerField cannot
+ * introduce a foreign field, because Caddy's PATCH requires the key to already exist at
+ * the target path (see safeFallback below) -- it can only overwrite a field the issuer
+ * already carries. And buildTlsConfig writes `module: "acme"` itself, so the
+ * absent-apps/tls branch is ACME by construction.
+ *
+ * Caller must have run validateIssuerShape first: the path is assumed present.
+ */
+function validateIssuerModule(tls: Record<string, unknown>): string | null {
+  // Same cast as mergeIssuerFields -- the path is shape-checked before we get here.
+  const automation = tls.automation as { policies: Array<{ issuers: Array<Record<string, unknown>> }> };
+  const found = automation.policies[0].issuers[0].module;
+  if (found === ACME_ISSUER_MODULE) return null;
+  const describe = found === undefined ? "absent" : JSON.stringify(found);
+  return (
+    `Refusing to write an ACME field onto a non-ACME issuer: ` +
+    `apps/tls.automation.policies[0].issuers[0].module is ${describe}, not "${ACME_ISSUER_MODULE}". ` +
+    `email/ca/profile are fields of the acme issuer module only. Use caddy_config_set with an explicit ` +
+    `path to edit this issuer, or point this tool at a config whose first policy uses an acme issuer.`
+  );
+}
+
 /**
  * Outcome of the safe fallback after a PATCH failure.
  *  - kind="ok": the fallback succeeded; caller emits the standard success message.
@@ -111,10 +146,32 @@ type FallbackOutcome =
   | { kind: "tool-error"; result: { isError: true; content: Array<{ type: "text"; text: string }> } };
 
 /**
+ * Build the "PATCH failed and the fallback will not proceed" result. All three refusal
+ * branches below share the same two-line preamble; only the trailing reason differs.
+ */
+function refuseFallback(label: string, patchRes: ApiResponse, detail: string): FallbackOutcome {
+  return {
+    kind: "tool-error",
+    result: {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text:
+            `Error: Failed to set ${label}.\n` +
+            `  PATCH attempt: ${patchRes.error || `HTTP ${patchRes.status}`}\n` +
+            `  ${detail}`,
+        },
+      ],
+    },
+  };
+}
+
+/**
  * Run the safe fallback after a PATCH failure: GET apps/tls, then either
  *  - POST a fresh apps/tls (when none exists),
  *  - merge into existing config and PUT it back (preserves siblings), or
- *  - refuse with a shape-specific error (do not clobber).
+ *  - refuse: a shape-specific error (do not clobber), or a non-ACME issuer module.
  */
 async function safeFallback(label: string, patchRes: ApiResponse, fields: IssuerFields): Promise<FallbackOutcome> {
   const getRes = await api.configGet<unknown>("apps/tls");
@@ -135,44 +192,31 @@ async function safeFallback(label: string, patchRes: ApiResponse, fields: Issuer
 
   // GET succeeded with a value — must be an object to be a usable apps/tls config.
   if (!isPlainObject(getRes.data)) {
-    return {
-      kind: "tool-error",
-      result: {
-        isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text:
-              `Error: Failed to set ${label}.\n` +
-              `  PATCH attempt: ${patchRes.error || `HTTP ${patchRes.status}`}\n` +
-              `  Refusing to clobber existing apps/tls: GET returned a non-object value. ` +
-              `Use caddy_config_set with an explicit path to update it safely.`,
-          },
-        ],
-      },
-    };
+    return refuseFallback(
+      label,
+      patchRes,
+      `Refusing to clobber existing apps/tls: GET returned a non-object value. ` +
+        `Use caddy_config_set with an explicit path to update it safely.`,
+    );
   }
 
   // Branch 3: existing apps/tls but the issuer sub-path we'd merge into is missing/wrong.
   const shapeError = validateIssuerShape(getRes.data);
   if (shapeError) {
-    return {
-      kind: "tool-error",
-      result: {
-        isError: true,
-        content: [
-          {
-            type: "text" as const,
-            text:
-              `Error: Failed to set ${label}.\n` +
-              `  PATCH attempt: ${patchRes.error || `HTTP ${patchRes.status}`}\n` +
-              `  Refusing to clobber existing apps/tls: ${shapeError}. ` +
-              `Use caddy_config_set with an explicit path (e.g. apps/tls/automation/policies) ` +
-              `to update it safely.`,
-          },
-        ],
-      },
-    };
+    return refuseFallback(
+      label,
+      patchRes,
+      `Refusing to clobber existing apps/tls: ${shapeError}. ` +
+        `Use caddy_config_set with an explicit path (e.g. apps/tls/automation/policies) ` +
+        `to update it safely.`,
+    );
+  }
+
+  // Branch 3b: the path exists, but the issuer sitting there is not an ACME one, so
+  // `email`/`ca`/`profile` are not its fields. Refuse rather than write a foreign key.
+  const moduleError = validateIssuerModule(getRes.data);
+  if (moduleError) {
+    return refuseFallback(label, patchRes, moduleError);
   }
 
   // Branch 2: shape is good — merge into a deep copy and write it back whole so siblings
@@ -201,6 +245,10 @@ async function safeFallback(label: string, patchRes: ApiResponse, fields: Issuer
  * Shared by set_email / set_acme_ca / set_acme_profile so all three keep
  * identical clobber-safety semantics -- the fallback is the delicate part, and
  * three hand-copied versions of it would drift.
+ *
+ * The PATCH here needs no issuer-module guard: it only succeeds when the key already
+ * exists on that issuer, so it can overwrite an ACME field but never add one. The
+ * fallback's merge path is the one that can, and it checks (see validateIssuerModule).
  */
 async function setIssuerField(field: keyof IssuerFields, value: string, label: string) {
   const patchRes = await api.configPatch(`apps/tls/automation/policies/0/issuers/0/${field}`, value);
@@ -220,8 +268,9 @@ export function registerTlsTools(server: McpServer) {
     "Get or configure TLS/HTTPS settings. Actions: 'status' shows current TLS config, 'set_email' sets the ACME email, " +
       "'set_acme_ca' sets the ACME CA URL, 'set_acme_profile' sets the ACME profile (Caddy 2.10+), " +
       "'ech_status' reads the Encrypted ClientHello config (Caddy 2.10+, read-only here). " +
-      "Works on both fresh and existing Caddy instances. Writes target policies[0].issuers[0] only -- " +
-      "on a multi-policy TLS config, edit the intended policy with caddy_config_set instead.",
+      "Works on both fresh and existing Caddy instances. Writes target policies[0].issuers[0] only, and only " +
+      "when that issuer's module is 'acme' -- on a multi-policy TLS config, or one whose first issuer is " +
+      "'internal' (Caddy's local CA), edit the intended issuer with caddy_config_set instead.",
     {
       action: z
         .enum(["status", "set_email", "set_acme_ca", "set_acme_profile", "ech_status"])
@@ -277,7 +326,13 @@ export function registerTlsTools(server: McpServer) {
         if (!profile) return missingArgError("profile is required for set_acme_profile action");
         return setIssuerField("profile", profile, "ACME profile");
       }
-      return { isError: true, content: [{ type: "text" as const, text: `Unknown action: ${action}` }] };
+      // Unreachable, and deliberately not live error handling: zod rejects any value
+      // outside the enum before this handler runs, and every member is handled above.
+      // TypeScript still demands a terminal return, so this one doubles as an
+      // exhaustiveness assertion -- add a member to the action enum without a branch for
+      // it and the assignment to `never` stops compiling, here, at the omission.
+      const unhandled: never = action;
+      return { isError: true, content: [{ type: "text" as const, text: `Unknown action: ${String(unhandled)}` }] };
     },
   );
 }


### PR DESCRIPTION
Applies a full-pass review punch list, three adversarially-verified follow-up reviews, a coverage pass, and a ship-readiness audit driven against a live Caddy 2.11.4.

`main` is untouched; nothing here is released. No CI runs on this repo by design, so the local gate below is the gate.

## The one that matters

Config paths were interpolated into the request URL unencoded, so a `#` or `?` in a config key truncated it. Reproduced against Caddy 2.11.4:

```
raw     /config/apps/http/servers/prod#1   -> deleted "prod"    (wrong server, HTTP 200 "success")
encoded /config/apps/http/servers/prod%231 -> deleted "prod#1"  (correct, "prod" intact)
```

`caddy_config_delete { path: "apps/http/servers/prod#1" }` deleted the **parent** server and reported success. Fixed by encoding per segment, so `/` keeps its separator meaning; traversal rejection still runs on the decoded form, so a literal `..` is refused and a supplied `%2e%2e` is escaped rather than decoded into one.

## First-run path was broken

Found by driving `bin/caddy-mcp.mjs` as a real MCP client against a config-less Caddy, not by reading tests.

- A server created **exactly as the tool's own advice said** could not accept its first route. The advice omitted `"routes": []` (a POST creates a missing `routes` key as an *object*, so the next call died on `cannot unmarshal object into ... RouteList`) *and* `mode: "append"` (the default `overwrite` is a PATCH that fails with `key does not exist`). A live test now follows the advice verbatim and adds a route to what it produces.
- `caddy_list_servers` answered a fresh instance with `{"error":"invalid traversal path at: config/apps/http"}` — a Go internal error from the tool whose job is to say what exists. Now reports `No HTTP servers configured`.
- `serverNotFoundError` was unreachable from all three call sites: `isParentMissing` matched only `404` / `key does not exist`, but live Caddy answers a POST under a missing server with `500 invalid traversal path` — a shape no mocked fixture produced.

## Also fixed

- `caddy_list_routes` reported an **unknown** server as an empty one. Caddy answers an unknown name with `200 null`, not 404. The new error names both possible causes, because an absent key and a null-valued key are byte-identical on the wire and both are reachable.
- `caddy_remove_route` could delete a non-route object by `@id` (`@id`s are config-global).
- `https://` upstreams were silently downgraded to plaintext.
- `caddy_tls` would write ACME fields onto a non-ACME issuer, and `set_acme_ca` would repoint an `internal` issuer's own `ca` at an ACME directory URL.
- `CADDY_MCP_SANDBOX=1` **denied every request** — endpoint mismatch, a port-pinned grant the `fetch` check never matches, and a missing env grant. A unix-socket admin URL additionally produced a bare `--allow-net`, granting the whole network for the most hardened configuration Caddy recommends. Verified against oam 0.9.0.
- Empty `tls_connection_policies` reported `TLS: enabled`; resource reads could render `Error: undefined`.
- Two MCP hints were wrong: `caddy_config_by_id` is destructive, and neither `caddy_remove_route` nor `caddy_config_delete` is idempotent by index.

## Tests

~100 added. Four run against a live Caddy, which is how several of these were found — the mocked suite cannot see what the admin API actually returns, and that blind spot is what let them ship.

```
Windows + live Caddy   464 passed |  34 skipped
POSIX (WSL)            478 passed |  20 skipped   <- launcher + unix-socket suites only run here
tsc --noEmit           clean
biome check            clean
```

The POSIX row matters: ~30 tests are `describe.skipIf(isWin)` and never execute on the Windows dev box, so "green on Windows" overstated coverage of the launcher and of `sendViaUnixSocket`.

## Packaging

`esbuild` moved into `devDependencies` — `scripts/build-binary.mjs` imports it directly but it resolved only transitively. Regenerating the lockfile also corrected a stale `bin` path; `npm ci` would have failed before this.

## Reviewing

Worth a close look at the error-message wording. Several messages here deliberately name **two** causes rather than one, because the responses are indistinguishable on the wire — this repo deprecated 1.2.5 for confidently naming a single cause when the signal had two, and one draft in this branch repeated that mistake before an adversarial pass caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
